### PR TITLE
feat(auth): add staff permissions, login rate limiting, and is_staff claim

### DIFF
--- a/backend/blog/auth_views.py
+++ b/backend/blog/auth_views.py
@@ -79,6 +79,10 @@ class SocialAuthView(APIView):
 
         refresh = RefreshToken.for_user(user)
         return Response(
-            {"access": str(refresh.access_token), "refresh": str(refresh)},
+            {
+                "access": str(refresh.access_token),
+                "refresh": str(refresh),
+                "is_staff": user.is_staff,
+            },
             status=status.HTTP_200_OK,
         )

--- a/backend/blog/permissions.py
+++ b/backend/blog/permissions.py
@@ -1,0 +1,15 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class IsStaffOrReadOnly(BasePermission):
+    """
+    Anyone can read (GET, HEAD, OPTIONS).
+    Only staff users can write (POST, PUT, PATCH, DELETE).
+    """
+
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:
+            return True
+        return bool(
+            request.user and request.user.is_authenticated and request.user.is_staff
+        )

--- a/backend/blog/tests.py
+++ b/backend/blog/tests.py
@@ -1,5 +1,15 @@
 import pytest
+from django.contrib.auth.models import User
 from django.urls import reverse
+from rest_framework_simplejwt.tokens import RefreshToken
+
+
+def auth_header(user):
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+
+# ── Read endpoints ────────────────────────────────────────────────────────────
 
 
 @pytest.mark.django_db
@@ -12,3 +22,70 @@ def test_post_list_returns_200(client):
 def test_category_list_returns_200(client):
     response = client.get(reverse("category-list"))
     assert response.status_code == 200
+
+
+# ── Write permissions ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_post_create_requires_auth(client):
+    """Unauthenticated POST returns 401."""
+    response = client.post(
+        reverse("post-list"),
+        {"title": "T", "slug": "t", "body": "b", "status": "draft"},
+        content_type="application/json",
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_post_create_forbidden_for_non_staff(client):
+    """Authenticated but non-staff POST returns 403."""
+    user = User.objects.create_user(username="reader", password="pass", is_staff=False)
+    response = client.post(
+        reverse("post-list"),
+        {"title": "T", "slug": "t", "body": "b", "status": "draft"},
+        content_type="application/json",
+        **auth_header(user),
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_post_create_allowed_for_staff(client):
+    """Staff POST creates and returns 201."""
+    user = User.objects.create_user(username="author", password="pass", is_staff=True)
+    response = client.post(
+        reverse("post-list"),
+        {"title": "Hello", "slug": "hello", "body": "World", "status": "draft"},
+        content_type="application/json",
+        **auth_header(user),
+    )
+    assert response.status_code == 201
+
+
+# ── Token endpoint returns is_staff ──────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_token_response_includes_is_staff_false(client):
+    User.objects.create_user(username="reader", password="pass123", is_staff=False)
+    response = client.post(
+        reverse("token_obtain_pair"),
+        {"username": "reader", "password": "pass123"},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert response.json()["is_staff"] is False
+
+
+@pytest.mark.django_db
+def test_token_response_includes_is_staff_true(client):
+    User.objects.create_user(username="author", password="pass123", is_staff=True)
+    response = client.post(
+        reverse("token_obtain_pair"),
+        {"username": "author", "password": "pass123"},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert response.json()["is_staff"] is True

--- a/backend/blog/token.py
+++ b/backend/blog/token.py
@@ -1,0 +1,29 @@
+from rest_framework.throttling import AnonRateThrottle
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework_simplejwt.views import TokenObtainPairView
+
+
+class LoginRateThrottle(AnonRateThrottle):
+    """
+    Separate throttle scope for the login endpoint so we can cap it
+    tightly (5 attempts/minute) without restricting other anonymous reads.
+    """
+
+    scope = "login"
+
+
+class StaffClaimTokenSerializer(TokenObtainPairSerializer):
+    """
+    Adds is_staff to the token response so the frontend can gate
+    write actions without needing a separate profile endpoint.
+    """
+
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        data["is_staff"] = self.user.is_staff
+        return data
+
+
+class StaffTokenObtainPairView(TokenObtainPairView):
+    serializer_class = StaffClaimTokenSerializer
+    throttle_classes = [LoginRateThrottle]

--- a/backend/blog/views.py
+++ b/backend/blog/views.py
@@ -1,11 +1,13 @@
 from rest_framework import generics
 
 from .models import Category, Post
+from .permissions import IsStaffOrReadOnly
 from .serializers import CategorySerializer, PostSerializer
 
 
 class PostListView(generics.ListCreateAPIView):
     serializer_class = PostSerializer
+    permission_classes = [IsStaffOrReadOnly]
 
     def get_queryset(self):
         return Post.objects.filter(status="published").order_by("-created_at")
@@ -22,3 +24,4 @@ class PostDetailView(generics.RetrieveAPIView):
 class CategoryListView(generics.ListCreateAPIView):
     serializer_class = CategorySerializer
     queryset = Category.objects.all()
+    permission_classes = [IsStaffOrReadOnly]

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -39,6 +39,9 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": (
         "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ),
+    "DEFAULT_THROTTLE_RATES": {
+        "login": "5/minute",
+    },
 }
 
 MIDDLEWARE = [

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -17,11 +17,17 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.views import TokenRefreshView
+
+from blog.token import StaffTokenObtainPairView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("blog.urls")),
-    path("api/auth/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path(
+        "api/auth/token/",
+        StaffTokenObtainPairView.as_view(),
+        name="token_obtain_pair",
+    ),
     path("api/auth/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
 ]

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/blog/create/page.tsx
+++ b/frontend/src/app/blog/create/page.tsx
@@ -26,13 +26,13 @@ function slugify(text: string) {
 
 export default function CreatePostPage() {
   const router = useRouter();
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const [categories, setCategories] = useState<Category[]>([]);
   const [title, setTitle] = useState("");
   const [slug, setSlug] = useState("");
   const [body, setBody] = useState("");
   const [categoryId, setCategoryId] = useState<number | null>(null);
-  const [status, setStatus] = useState("draft");
+  const [postStatus, setPostStatus] = useState("draft");
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -44,7 +44,7 @@ export default function CreatePostPage() {
     setSlug(slugify(val));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!title || !slug || !body) {
       toast.error("Title, slug, and body are required.");
@@ -63,15 +63,23 @@ export default function CreatePostPage() {
           slug,
           body,
           category_id: categoryId,
-          status,
-          published_at: status === "published" ? new Date().toISOString() : null,
+          status: postStatus,
+          published_at: postStatus === "published" ? new Date().toISOString() : null,
         }),
       });
       if (!res.ok) {
+        if (res.status === 401) {
+          toast.error("Session expired. Please sign in again.");
+          router.push("/login");
+          return;
+        }
+        if (res.status === 403) {
+          toast.error("You don't have permission to create posts.");
+          return;
+        }
         const err = await res.json();
         const message = Object.values(err).flat().join(" ");
         toast.error(message || "Failed to create post.");
-        setLoading(false);
         return;
       }
       const post = await res.json();
@@ -79,9 +87,31 @@ export default function CreatePostPage() {
       router.push(`/blog/${post.slug}`);
     } catch {
       toast.error("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
+
+  if (sessionStatus === "loading") return null;
+
+  if (!session?.isStaff) {
+    return (
+      <>
+        <Header />
+        <main className="min-h-screen bg-background flex items-center justify-center px-4">
+          <div className="text-center">
+            <p className="text-4xl font-black uppercase tracking-tight text-primary mb-3">403</p>
+            <p className="text-muted-foreground text-sm mb-6">
+              You don&apos;t have permission to create posts.
+            </p>
+            <Link href="/blog" className="text-primary text-sm font-medium hover:underline">
+              ← Back to the blog
+            </Link>
+          </div>
+        </main>
+      </>
+    );
+  }
 
   return (
     <>
@@ -155,8 +185,8 @@ export default function CreatePostPage() {
                   <div className="flex flex-col gap-1.5">
                     <label className="text-sm font-medium">Status</label>
                     <select
-                      value={status}
-                      onChange={(e) => setStatus(e.target.value)}
+                      value={postStatus}
+                      onChange={(e) => setPostStatus(e.target.value)}
                       className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                     >
                       <option value="draft">Draft</option>
@@ -188,7 +218,11 @@ export default function CreatePostPage() {
 
             <div className="flex items-center gap-4">
               <Button type="submit" disabled={loading}>
-                {loading ? "Publishing..." : status === "published" ? "Publish post" : "Save draft"}
+                {loading
+                  ? "Publishing..."
+                  : postStatus === "published"
+                    ? "Publish post"
+                    : "Save draft"}
               </Button>
               <Link href="/blog" className="text-sm text-muted-foreground hover:underline">
                 Cancel

--- a/frontend/src/app/blog/page.tsx
+++ b/frontend/src/app/blog/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
+import { auth } from "@/auth";
 import Header from "@/components/layout/Header";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { getPosts } from "@/lib/api";
 
 export default async function BlogPage() {
-  const posts = await getPosts();
+  const [posts, session] = await Promise.all([getPosts(), auth()]);
 
   return (
     <>
@@ -19,12 +20,14 @@ export default async function BlogPage() {
           <p className="text-xs uppercase tracking-[0.25em] text-muted-foreground mb-6">
             Thoughts on software engineering &amp; learning in public
           </p>
-          <Link
-            href="/blog/create"
-            className="inline-flex items-center gap-2 text-sm font-semibold text-primary border border-primary/40 rounded-full px-4 py-1.5 hover:bg-primary/10 transition-colors"
-          >
-            + Write a post
-          </Link>
+          {session?.isStaff && (
+            <Link
+              href="/blog/create"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-primary border border-primary/40 rounded-full px-4 py-1.5 hover:bg-primary/10 transition-colors"
+            >
+              + Write a post
+            </Link>
+          )}
         </section>
 
         {/* Posts grid */}

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -3,8 +3,9 @@ import type { JWT } from "next-auth/jwt";
 import Google from "next-auth/providers/google";
 import Credentials from "next-auth/providers/credentials";
 
-// Django access tokens expire in 5 minutes — refresh 30 seconds before that
-const ACCESS_TOKEN_TTL = 4.5 * 60 * 1000;
+// Refresh the Django token 5 minutes before its 1-hour expiry.
+// This ensures we never send an expired token to the API.
+const ACCESS_TOKEN_TTL = 55 * 60 * 1000;
 
 async function refreshAccessToken(token: JWT): Promise<JWT> {
   try {
@@ -53,13 +54,14 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           name: credentials.username as string,
           accessToken: tokens.access,
           refreshToken: tokens.refresh,
+          isStaff: tokens.is_staff ?? false,
         };
       },
     }),
   ],
   callbacks: {
     async jwt({ token, user, account }) {
-      // Google sign-in — exchange for a Django JWT
+      // Google sign-in — exchange Google identity for a Django JWT
       if (account?.provider === "google" && user) {
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/social/`, {
           method: "POST",
@@ -73,6 +75,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             accessToken: tokens.access,
             refreshToken: tokens.refresh,
             accessTokenExpires: Date.now() + ACCESS_TOKEN_TTL,
+            isStaff: tokens.is_staff ?? false,
           };
         }
       }
@@ -84,6 +87,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           accessToken: (user as { accessToken?: string }).accessToken,
           refreshToken: (user as { refreshToken?: string }).refreshToken,
           accessTokenExpires: Date.now() + ACCESS_TOKEN_TTL,
+          isStaff: (user as { isStaff?: boolean }).isStaff ?? false,
         };
       }
 
@@ -92,11 +96,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         return token;
       }
 
-      // Token expired — refresh it
+      // Token expired — refresh it (isStaff is preserved via spread)
       return refreshAccessToken(token);
     },
     async session({ session, token }) {
       session.accessToken = token.accessToken as string | undefined;
+      session.isStaff = token.isStaff ?? false;
       return session;
     },
   },

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -80,6 +80,11 @@ describe("createPost", () => {
     expect(options.headers.Authorization).toBeUndefined();
   });
 
+  it("throws Unauthorized on 401 response", async () => {
+    mockResponse({}, false, 401);
+    await expect(createPost(postData, "expired-token")).rejects.toThrow("Unauthorized");
+  });
+
   it("throws when creation fails", async () => {
     mockResponse({}, false, 400);
     await expect(createPost(postData, "token")).rejects.toThrow("Failed to create post");
@@ -118,6 +123,13 @@ describe("createCategory", () => {
     await createCategory({ name: "Django", slug: "django" });
     const [, options] = mockFetch.mock.calls[0];
     expect(options.headers.Authorization).toBeUndefined();
+  });
+
+  it("throws Unauthorized on 401 response", async () => {
+    mockResponse({}, false, 401);
+    await expect(
+      createCategory({ name: "Django", slug: "django" }, "expired-token")
+    ).rejects.toThrow("Unauthorized");
   });
 
   it("throws when creation fails", async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -47,6 +47,7 @@ export async function createPost(
     headers,
     body: JSON.stringify(data),
   });
+  if (res.status === 401) throw new Error("Unauthorized");
   if (!res.ok) throw new Error("Failed to create post");
   return res.json();
 }
@@ -68,6 +69,7 @@ export async function createCategory(
     headers,
     body: JSON.stringify(data),
   });
+  if (res.status === 401) throw new Error("Unauthorized");
   if (!res.ok) throw new Error("Failed to create category");
   return res.json();
 }

--- a/frontend/src/types/next-auth.d.ts
+++ b/frontend/src/types/next-auth.d.ts
@@ -3,6 +3,7 @@ import "next-auth";
 declare module "next-auth" {
   interface Session {
     accessToken?: string;
+    isStaff?: boolean;
   }
 }
 
@@ -11,6 +12,7 @@ declare module "next-auth/jwt" {
     accessToken?: string;
     refreshToken?: string;
     accessTokenExpires?: number;
+    isStaff?: boolean;
     error?: string;
   }
 }


### PR DESCRIPTION
## Summary

- `IsStaffOrReadOnly` permission class — read for everyone, write only for staff; applied to post and category endpoints
- `LoginRateThrottle` caps `/api/auth/token/` at 5 attempts/minute per IP
- `is_staff` included in token response (credentials + Google OAuth) and threaded through NextAuth session
- `ACCESS_TOKEN_TTL` fixed from 4.5 minutes to 55 minutes to match Django's 1-hour token lifetime
- "Write a post" button hidden for non-staff; create page shows 403 screen for non-staff; 401/403 handled explicitly in submit handler

## Test plan

- [ ] 7 Django tests pass: read endpoints still 200, unauthenticated POST → 401, non-staff POST → 403, staff POST → 201, token response includes `is_staff`
- [ ] 43 frontend tests pass with 100% coverage
- [ ] Log in as a non-staff user — "Write a post" button is hidden on `/blog`
- [ ] Navigate directly to `/blog/create` as non-staff — 403 screen appears
- [ ] Log in as a staff user — button visible, create form renders, post publishes successfully
- [ ] CI `frontend-test` and `backend-test` jobs pass