### PR TITLE
feat(docker): containerise Django backend with gunicorn and Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Root .env — used by docker-compose.yml
+# Copy to .env and fill in real values before running docker compose up
+
+DB_PASSWORD=your-db-password
+SECRET_KEY=your-django-secret-key
+ALLOWED_HOSTS=localhost,127.0.0.1
+CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 /test.md
+/.env
 .next/
 dist/
 build/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+venv/
+.env
+*.pyc
+__pycache__/
+.pytest_cache/
+db.sqlite3
+staticfiles/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN chmod +x entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -99,6 +99,7 @@ USE_I18N = True
 USE_TZ = True
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 CORS_ALLOWED_ORIGINS = env.list(
     "CORS_ALLOWED_ORIGINS",

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+echo "Running migrations..."
+python manage.py migrate --noinput
+
+echo "Collecting static files..."
+python manage.py collectstatic --noinput
+
+echo "Starting gunicorn..."
+exec gunicorn core.wsgi:application \
+    --bind 0.0.0.0:8000 \
+    --workers 2 \
+    --timeout 120 \
+    --access-logfile - \
+    --error-logfile -

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.11.1
 Django==6.0.5
+gunicorn==26.0.0
 django-cors-headers==4.9.0
 django-environ==0.13.0
 djangorestframework==3.17.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: portfolio_blog
+      POSTGRES_USER: portfolio_user
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U portfolio_user -d portfolio_blog"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build: ./backend
+    environment:
+      SECRET_KEY: ${SECRET_KEY}
+      DEBUG: "False"
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1}
+      DATABASE_URL: postgres://portfolio_user:${DB_PASSWORD}@db:5432/portfolio_blog
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
- Dockerfile: python:3.12-slim, installs requirements, runs entrypoint.sh
- entrypoint.sh: migrate → collectstatic → gunicorn (2 workers, logs to stdout)
- .dockerignore: excludes venv/, .env, __pycache__, db.sqlite3, staticfiles/
- docker-compose.yml: postgres:16-alpine (healthcheck) + backend service; DATABASE_URL uses db hostname; postgres_data volume persists DB across restarts
- .env.example: root-level template for DB_PASSWORD, SECRET_KEY, ALLOWED_HOSTS, CORS_ALLOWED_ORIGINS read by docker-compose
- requirements.txt: add gunicorn==26.0.0
- settings.py: add STATIC_ROOT for collectstatic
- .gitignore: add /.env so root docker env file is never committed