### PR TITLE
docs: recover planning pack, add project docs and blog series

### DIFF
--- a/.claude/nextjs-django-roadmap.md
+++ b/.claude/nextjs-django-roadmap.md
@@ -1,0 +1,89 @@
+# Next.js + Django Roadmap (Agreed Direction)
+
+## Strategy Statement
+Yes, this is the right direction: use Next.js for SEO and frontend velocity, and Django/PostgreSQL for backend power and Python learning.
+
+## Recommended Architecture
+- Frontend: Next.js (App Router) + Tailwind CSS
+- Backend: Django + Django REST Framework
+- Database: PostgreSQL
+- Content: Blog managed in Django admin, consumed by Next.js via API
+- Deployment: Vercel (frontend) + Render/Fly/Railway (Django + Postgres)
+
+This gives strong SEO plus practical full-stack backend depth.
+
+## Step-by-Step Implementation Plan
+
+### 1) Define Scope and Data Model
+- Decide MVP pages: Home, Projects, Blog list, Blog detail, About, Contact, Admin.
+- Define models: Post, Category, Tag, Author, Project, ContactMessage.
+- Define required SEO fields: slug, meta_title, meta_description, og_image, published_at, status.
+
+### 2) Set Up Repositories and Environments
+- Create frontend (Next.js + Tailwind) and backend (Django) folders.
+- Configure .env strategy for both apps.
+- Set up GitHub Actions early (lint + test on PR).
+
+### 3) Build Django Backend Foundation
+- Initialize Django project, add DRF, CORS, PostgreSQL config.
+- Create blog app and core models.
+- Add Django admin customization for content editing.
+- Add API endpoints:
+  - /api/posts/ (published list, pagination, filtering)
+  - /api/posts/<slug>/ (detail)
+  - /api/projects/
+  - /api/contact/
+- Add serializers, validation, and basic permissions.
+
+### 4) Build Next.js Frontend Foundation
+- Scaffold Next.js app with Tailwind and design tokens.
+- Create layout, header/nav, footer, responsive structure.
+- Migrate existing portfolio sections into reusable components.
+- Create typed API client for Django endpoints.
+
+### 5) Implement Blog UI + SEO
+- Blog listing page with pagination and tag/category filters.
+- Blog detail page by slug.
+- Add Next.js metadata (generateMetadata) per post.
+- Add sitemap and robots.
+- Add JSON-LD for blog posts.
+
+### 6) Add Auth and Content Workflow (If Needed)
+- Start with Django admin-only publishing.
+- Optional later: add editor dashboard in Next.js with JWT/session auth.
+- Add draft/published workflow and preview support.
+
+### 7) Add Advanced Portfolio Features
+- Project detail pages.
+- Search across posts/projects.
+- Related posts.
+- Reading time, table of contents, code block styling.
+- Newsletter or contact automation.
+
+### 8) Quality and Testing
+- Backend tests: model + API tests.
+- Frontend tests: component tests + basic e2e paths.
+- Accessibility pass (headings, contrast, keyboard nav).
+- Performance pass (image optimization, caching, ISR/revalidation).
+
+### 9) Deployment and Production Hardening
+- Deploy Django with managed Postgres.
+- Deploy Next.js on Vercel.
+- Configure CORS, allowed hosts, secure cookies/headers.
+- Add monitoring/logging and backups.
+
+### 10) Ongoing Iteration
+- Add analytics.
+- Add CMS polish in Django admin.
+- Improve authoring flow and content templates.
+
+## Learning Path (Python/Django + Next.js)
+- Week 1: Django models, admin, DRF serializers/views, Postgres basics.
+- Week 2: Build blog API and validation.
+- Week 3: Next.js App Router, metadata, data fetching, Tailwind system.
+- Week 4: Integrate both, deploy, and add SEO/structured data.
+
+## Why This Fit Is Strong
+- SEO-first rendering from Next.js.
+- Deep Python/Django learning by owning models, APIs, admin, auth, and DB design.
+- Avoid locking blog content in frontend-only markdown files.

--- a/.claude/objectives.md
+++ b/.claude/objectives.md
@@ -1,0 +1,31 @@
+# Objectives
+
+## Product Goals
+
+- Migrate the portfolio from static HTML/CSS/JS to Next.js + Tailwind CSS + shadcn/ui + Framer Motion. **(done)**
+- Ship the UI first with static data, then layer in the backend. **(done)**
+- Add a Django + PostgreSQL backend to power the blog. **(done)**
+- Let a staff author publish markdown posts; let readers comment and like. **(done)**
+- Preserve and improve SEO (metadata, sitemap, structured data). **(in progress)**
+
+## Learning Goals
+
+- Build practical Next.js App Router skills — components, routing, server vs. client, Tailwind. **(done)**
+- Build practical Django skills — models, admin, DRF serializers/views, permissions. **(done)**
+- Learn token auth end-to-end: SimpleJWT + NextAuth (credentials + Google), refresh flow. **(done)**
+- Practise a real delivery workflow: linting, tests + coverage, CI, Docker. **(done)**
+
+## MVP Definition — met
+
+- Next.js app with all portfolio sections: Hero, Projects, About, Contact.
+- Blog powered by the Django API: list, detail (markdown), create, comments, likes.
+- Auth with staff-gated publishing.
+- Dark/light mode.
+- Tested (Vitest 100% on core modules + pytest) and CI-enforced.
+
+## Current Non-Goals
+
+- No pagination / category filtering yet (planned polish).
+- No SSR caching / ISR tuning yet (fetches are `no-store` for now).
+- No custom analytics or newsletter.
+- Production deployment still pending.

--- a/.claude/plan.md
+++ b/.claude/plan.md
@@ -6,67 +6,67 @@
 - Improve Next.js / React skills by building on top of what's already here.
 - End result: a portfolio site with a working blog powered by Django + PostgreSQL.
 
-## Current State (Next.js frontend)
+## Frontend (Next.js) — done
 
-Already built in `frontend/src/`:
-
-- `layout.tsx` — root shell, Poppins font, ThemeProvider, Lottie script
-- `page.tsx` — assembles all sections
-- `components/layout/Header.tsx` — fixed header, dark mode toggle, mobile menu
-- `components/sections/Hero.tsx` — typing animation, social links, Lottie
-- `components/sections/Projects.tsx` — project cards + case study modal
-- `components/sections/About.tsx` — bio, skills accordion
-- `components/sections/Contact.tsx` — Formspree contact form
-- `data/projects.ts` — static project data
-- `globals.css` — design tokens (light/dark), Tailwind v4
-
-## What's Left on the Frontend
-
-- [ ] Footer component
-- [ ] Verify the site looks right end-to-end (run `npm run dev`)
-- [ ] SEO: `generateMetadata`, `sitemap.xml`, `robots.txt`
+- [x] App Router shell: `layout.tsx`, `page.tsx`, `ThemeProvider`
+- [x] `Header` with dark-mode toggle + mobile menu
+- [x] Sections: Hero, Projects, About, Contact
+- [x] `data/projects.ts` static project data
+- [x] `globals.css` design tokens (light/dark), Tailwind v4
+- [x] shadcn/ui component set (button, card, badge, avatar, dropdown, etc.)
+- [ ] SEO: `generateMetadata`, `sitemap.xml`, `robots.txt`, JSON-LD
 - [ ] Deploy to Vercel
 
 ## Blog — Django + PostgreSQL Backend
 
-Build this in `backend/` once frontend is deployed.
+### Step 1: Django project scaffold — done
 
-### Step 1: Django project scaffold
+- [x] `backend/` Django project (`core`) + DRF, CORS, SimpleJWT
+- [x] PostgreSQL via `DATABASE_URL` (django-environ)
+- [x] `.env` strategy for both apps
 
-- Create `backend/` Django project.
-- Install: `django`, `djangorestframework`, `django-cors-headers`, `psycopg2-binary`, `python-dotenv`.
-- Connect to PostgreSQL (local dev DB).
-- Confirm `python manage.py runserver` works.
+### Step 2: Blog models — done
 
-### Step 2: Blog models
+- [x] `blog` app with `Category`, `Post` (+ `status`, `published_at`), `Comment`
+- [x] Registered in Django admin
+- [x] Migrations applied
 
-- Create a `blog` Django app.
-- Models: `Post` (title, slug, body, published_at, status), `Category` (name, slug).
-- Register both in Django admin.
-- Run migrations and confirm admin works.
+### Step 3: REST API — done
 
-### Step 3: REST API
+- [x] Serializers for `Category`, `Post`, `Comment`
+- [x] `GET/POST /api/posts/`, `GET /api/posts/<slug>/`, `GET/POST /api/categories/`
+- [x] `GET/POST /api/posts/<slug>/comments/`, like toggle endpoint
+- [x] Permissions: `IsStaffOrReadOnly`, `IsAuthenticatedOrReadOnly`
 
-- DRF serializers for `Post` and `Category`.
-- Endpoints:
-  - `GET /api/posts/` — published posts list
-  - `GET /api/posts/<slug>/` — single post
-  - `GET /api/categories/` — category list
-- Read-only for now (no auth needed yet).
+### Step 4: Connect Next.js to the API — done
 
-### Step 4: Connect Next.js to the API
+- [x] Typed API client in `frontend/src/lib/api.ts`
+- [x] `/blog` list page and `/blog/[slug]` detail page (server components)
+- [x] `/blog/create` page with markdown editor
+- [x] Blog link in Header nav
 
-- Add a typed API client in `frontend/src/lib/api.ts`.
-- Add `/blog` page — fetches post list from Django.
-- Add `/blog/[slug]` page — fetches single post.
-- Add Blog link to Header nav.
+### Step 5: Auth — done
 
-### Step 5: Polish
+- [x] SimpleJWT token + refresh endpoints
+- [x] NextAuth v5: Credentials + Google providers, token refresh callback
+- [x] `SocialAuthView` exchanges Google identity for a Django JWT
+- [x] Middleware-protected routes (`/blog/create`, `/blog/categories`)
+- [x] `is_staff` claim + login rate limiting (5/min)
 
-- Pagination on post list.
-- Category filter.
-- Reading time estimate.
-- Code block syntax highlighting.
+### Step 6: Quality & delivery — done
+
+- [x] Vitest at 100% coverage on core modules; pytest backend tests
+- [x] GitHub Actions CI (lint + test + build)
+- [x] Husky pre-commit / pre-push hooks
+- [x] Dockerised backend (gunicorn) + Postgres (docker-compose)
+
+### Step 7: Polish — remaining
+
+- [ ] Pagination on post list
+- [ ] Category filter on the blog list
+- [ ] Reading-time estimate
+- [ ] Code-block syntax highlighting
+- [ ] Deploy backend + frontend to production
 
 ## Branching Rule
 

--- a/.claude/progress.md
+++ b/.claude/progress.md
@@ -1,0 +1,77 @@
+# Progress Tracker
+
+## How to Use
+
+- Update this file at the end of each work session.
+- Move checkboxes in `.claude/plan.md` as tasks complete.
+- Keep entries short and factual.
+
+## Status Summary
+
+- Date: 2026-07-13
+- Overall Status: Core product shipped — blog is live end-to-end
+- Current Phase: Phase 6 — deployment & polish
+- Blockers: None
+
+## Where We Are
+
+The portfolio has been fully rebuilt as a Next.js + Django + PostgreSQL app.
+The blog works end-to-end: publish from an authenticated create page, read with
+markdown rendering, comment, and like. Both stacks are linted, tested, and the
+backend is containerised.
+
+Shipped:
+
+- Next.js 16 frontend (App Router, Tailwind v4, shadcn/ui, dark mode).
+- Django 6 + DRF backend with `Category`, `Post`, `Comment` models.
+- Typed API client and blog list / detail / create pages.
+- Markdown authoring (react-md-editor) and rendering (react-markdown + typography).
+- Auth: SimpleJWT + NextAuth v5 (credentials + Google), token refresh, protected routes.
+- Staff-only writes (`IsStaffOrReadOnly`), `is_staff` JWT claim, login rate limiting.
+- Comment threads with a like/unlike toggle and optimistic UI.
+- Vitest suite at 100% coverage on core modules; pytest for the backend.
+- GitHub Actions CI (lint + test + build) and Husky pre-commit / pre-push hooks.
+- Dockerised backend (gunicorn) + Postgres via docker-compose.
+
+## Session Log
+
+### 2026-04-23 (Sessions 1–2)
+
+- Created the `.claude/` planning pack. Agreed architecture: Next.js + Django + PostgreSQL.
+- Revamped static portfolio UI; decided to build the Next.js UI first, defer Django.
+
+### 2026-04-26 → 2026-05-16
+
+- Rebuilt the portfolio in Next.js (App Router, Tailwind v4). Refocused project direction.
+
+### 2026-05-17 → 2026-06-03
+
+- Scaffolded the Django blog app: models, serializers, admin.
+- Configured CORS, env vars, PostgreSQL, Ruff, Husky, and Prettier.
+
+### 2026-06-08 → 2026-06-09
+
+- Built blog list + detail pages against the Django API.
+- Added markdown rendering, then the markdown-editor create page.
+
+### 2026-06-11 → 2026-06-13
+
+- Added JWT auth, Google OAuth, and middleware-protected routes.
+- Added staff permissions, login rate limiting, and the `is_staff` claim.
+- Added the Vitest suite with 100% coverage enforcement.
+- Built the comment thread with likes; moved Sign in into the Header.
+
+### 2026-06-14
+
+- Containerised the Django backend with gunicorn and Postgres (docker-compose).
+
+### 2026-07-13
+
+- Recovered the `.claude/` planning pack after a machine change.
+- Recreated the human-facing `docs/` folder and a multi-part learning blog series.
+
+## Next 3 Actions
+
+1. Deploy: Next.js on Vercel, Django + Postgres on Render/Fly/Railway.
+2. SEO pass: `generateMetadata` per post, `sitemap.xml`, `robots.txt`, JSON-LD.
+3. Blog polish: pagination, category filtering, reading time, code highlighting.

--- a/.claude/transfer-to-new-project.md
+++ b/.claude/transfer-to-new-project.md
@@ -1,0 +1,36 @@
+# Transfer .claude Pack to a New Project
+
+## Purpose
+Use this file to copy the working planning system into another repository before implementation begins.
+
+## Files to Copy
+Copy these files as a group into the target repo's `.claude/` directory:
+- `.claude/objectives.md`
+- `.claude/plan.md`
+- `.claude/progress.md`
+- `.claude/claude-code-workflow.md`
+- `.claude/nextjs-django-roadmap.md`
+- `.claude/transfer-to-new-project.md`
+
+## First-Time Setup in Target Repository
+1. Create and switch to `develop` if it does not exist yet.
+2. Ensure `develop` tracks `origin/develop`.
+3. Start all new tasks from updated `develop`.
+
+Recommended command flow:
+- `git fetch origin`
+- `git checkout develop`
+- `git pull --ff-only origin develop`
+- `git checkout -b feat/your-description`
+
+## Session Workflow
+1. Review `.claude/progress.md`.
+2. Pick next unchecked item in `.claude/plan.md`.
+3. Implement one focused slice.
+4. Run checks.
+5. Update `.claude/progress.md` at session end.
+
+## Notes
+- Keep branch names short, lowercase, and hyphenated.
+- Use one branch per feature/fix/chore.
+- Merge branches into `develop` to keep history linear.

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ backend/.env
 *.pyo
 
 backend/db.sqlite3
-
-# Local docs
-docs/

--- a/blogs/README.md
+++ b/blogs/README.md
@@ -1,0 +1,40 @@
+# Learning in Public: Rebuilding My Portfolio as a Full-Stack App
+
+This is the story of taking my portfolio from a static HTML/CSS/JS site I built in
+2023 to a full-stack application with a Next.js frontend, a Django REST API, a
+PostgreSQL database, authentication, comments, tests, and Docker.
+
+I wrote it as a journey — the decisions, the dead ends, and the small "oh, *that's*
+how it works" moments — because that's the part tutorials skip. It's also **not
+finished**: the app is live end-to-end, but deployment, SEO, and polish are still
+ahead. I'll keep adding to the series as I go.
+
+## The series
+
+1. **[From a Static Site to Full Stack](./part-1-from-static-site-to-full-stack.md)**
+   — why I rebuilt a site that worked, how I chose the stack, and building the
+   Next.js frontend.
+2. **[Building the Blog's Backend with Django + DRF](./part-2-building-the-blog-backend-with-django.md)**
+   — my first real Django models, the admin, a REST API, and PostgreSQL.
+3. **[Wiring It Together: Markdown and Auth](./part-3-wiring-it-together-markdown-and-auth.md)**
+   — a typed API client, rendering markdown, and the part that took longest: JWT +
+   NextAuth + Google sign-in.
+4. **[Making It Real: Comments, Tests, CI & Docker](./part-4-comments-tests-ci-and-docker.md)**
+   — comments and likes, getting to 100% test coverage, a CI pipeline, Docker —
+   and an honest look at what's left.
+
+## The stack, at a glance
+
+| Layer | Tech |
+| --- | --- |
+| Frontend | Next.js 16 (App Router), TypeScript, Tailwind v4, shadcn/ui |
+| Backend | Django 6, Django REST Framework |
+| Database | PostgreSQL 16 |
+| Auth | SimpleJWT (API) + NextAuth v5 (client), Google OAuth |
+| Tooling | Ruff, ESLint, Prettier, pytest, Vitest, Husky, GitHub Actions, Docker |
+
+## How to read it
+
+Each post stands on its own, but they're in build order. Code snippets are real —
+lightly trimmed for clarity, but they match what's in the repo. Every post ends with
+a short "what I'd tell past me" so the lessons aren't buried in the code.

--- a/blogs/part-1-from-static-site-to-full-stack.md
+++ b/blogs/part-1-from-static-site-to-full-stack.md
@@ -1,0 +1,132 @@
+# Part 1 — From a Static Site to Full Stack
+
+*Series: [Learning in Public](./README.md) · Next: [Building the Backend →](./part-2-building-the-blog-backend-with-django.md)*
+
+---
+
+In 2023 I built my portfolio the honest way: hand-written HTML, CSS, and vanilla
+JavaScript, deployed to GitHub Pages. It had a mobile menu I wired up with event
+listeners, project cards that opened popups, a contact form with its own validation
+function, and — after a lot of commits with messages like *"solve largest
+contentful paint issue"* — a genuinely fast Lighthouse score. I converted images to
+WebP, lazy-loaded them, minified the CSS, and chased down layout shift.
+
+It worked. So why rebuild it?
+
+## Why tear down something that works
+
+Two reasons, and only one of them was technical.
+
+1. **I wanted to learn.** The static site had hit its ceiling as a *learning*
+   project. I could keep polishing pixels, but I wasn't learning anything new. I
+   wanted to understand how a real full-stack app fits together: a backend, a
+   database, authentication, an API contract between two apps.
+2. **I wanted a blog I actually owned.** Not markdown files hard-coded into the
+   frontend — a real content system I could write into, with categories, drafts,
+   and comments. That meant a database and an admin, which meant a backend.
+
+The rule I set for myself: *don't rebuild for the sake of it — rebuild to learn
+specific things.* I wrote those learning goals down before touching code.
+
+## Choosing the stack
+
+I gave myself a short list of decisions and a reason for each.
+
+**Frontend: Next.js.** I already knew React, and Next.js gave me server rendering
+for SEO (a portfolio that doesn't show up in search is a bad portfolio) plus a
+routing and data-fetching story that scales past "one HTML file per page."
+
+**Backend: Django + Django REST Framework.** I wanted to learn Python properly, and
+Django hands you an ORM, migrations, an admin UI, and auth out of the box. DRF turns
+models into a JSON API without much ceremony. For someone learning, "batteries
+included" was the whole point — I'd see how the pieces are *supposed* to fit before
+trying to assemble them myself.
+
+**Database: PostgreSQL.** The default serious choice, and the push I needed to stop
+avoiding "real" databases.
+
+The principle I kept coming back to, straight from my planning notes:
+
+> Avoid locking blog content in frontend-only markdown files.
+
+Content belongs in a database you can query, moderate, and grow — not in the git
+history of your UI. (The *learning notes*, like this series, are fine as markdown.
+Know which is which.)
+
+## Planning before code
+
+Before writing a line, I wrote three short docs: **objectives** (product + learning
+goals, plus explicit *non-goals* to stop scope creep), **plan** (the build split
+into one-branch-sized steps), and a **roadmap** (models → API → integration → auth →
+tests → deploy).
+
+This felt like overkill for a personal project. It wasn't. Months later I switched
+machines and lost my uncommitted working folder — those *committed* planning docs
+were the thing that let me pick the thread back up. **Write down what you're doing
+and why, and commit it. Your future self is a different person with amnesia.**
+
+## The phasing decision that saved me
+
+My first instinct was to build frontend and backend together. I changed my mind
+early and committed to a **frontend-first** approach: build the entire Next.js UI
+with *static, hard-coded data*, ship it, and only then start Django.
+
+Why? It let me get a working, deployable site fast (motivation matters), learn
+Next.js without also fighting CORS and migrations, and define the *shape* of my data
+from the UI's needs before building an API to match. One new hard concept at a time.
+
+## Building the frontend
+
+I scaffolded a Next.js App Router app in a `frontend/` folder with TypeScript and
+Tailwind v4, and added [shadcn/ui](https://ui.shadcn.com) for accessible base
+components (buttons, cards, badges, dropdowns) I could restyle instead of build from
+scratch.
+
+A few things clicked here that are worth calling out.
+
+**The App Router's mental model is "server by default."** Pages are async server
+components that can `await` data directly — no `useEffect`, no loading spinner
+boilerplate. You only reach for `"use client"` when you need interactivity (state,
+event handlers, browser APIs). Coming from create-react-app, this was the biggest
+shift, and the most freeing once it landed.
+
+**Design tokens made dark mode almost free.** I defined colours as CSS variables in
+`globals.css` for light and dark, wired up `next-themes` with a `ThemeProvider`, and
+then every component just used `bg-background` / `text-foreground`. Dark mode became
+a single class on `<html>` instead of a per-component chore.
+
+**Static data first was the right call.** I put my projects in a plain
+`data/projects.ts` file and built the whole UI — Hero with a typing animation, a
+Projects grid with case-study cards, About, Contact — against it. The site was
+real and deployable before a backend existed. When I later built the API, I already
+knew exactly what a `Post` needed to contain, because the UI had told me.
+
+The structure I landed on:
+
+```
+frontend/src/
+├── app/            routes (/, /blog, /blog/[slug], /blog/create, /login…)
+├── components/
+│   ├── layout/     Header (nav, dark-mode toggle, mobile menu)
+│   ├── sections/   Hero, Projects, About, Contact
+│   ├── blog/       CommentSection
+│   └── ui/         shadcn primitives
+├── lib/            api client, helpers
+└── data/           static project data
+```
+
+## What I'd tell past me
+
+- **Rebuild to learn a named thing, not because the old thing is "old."** If you
+  can't say what you'll learn, don't rebuild.
+- **Write the plan down and commit it to git.** Uncommitted notes are one new laptop
+  away from gone (ask me how I know).
+- **Ship the UI with fake data first.** It keeps you to one hard new concept at a
+  time and lets your interface define your data model.
+- **Learn the server/client split early.** In the App Router, "what runs where" is
+  the thing to get straight before anything else makes sense.
+
+Next up: the scary part for a frontend dev — building an actual backend. Django
+models, the admin, and turning them into a REST API.
+
+*Next: [Building the Blog's Backend with Django + DRF →](./part-2-building-the-blog-backend-with-django.md)*

--- a/blogs/part-2-building-the-blog-backend-with-django.md
+++ b/blogs/part-2-building-the-blog-backend-with-django.md
@@ -1,0 +1,206 @@
+# Part 2 — Building the Blog's Backend with Django + DRF
+
+*Series: [Learning in Public](./README.md) · Prev: [← From a Static Site to Full Stack](./part-1-from-static-site-to-full-stack.md) · Next: [Wiring It Together →](./part-3-wiring-it-together-markdown-and-auth.md)*
+
+---
+
+With the frontend shipped on static data, it was time for the part I'd been both
+excited and nervous about: a real backend. I'd never built one. This is where I
+learned Python and Django properly — by needing them for something.
+
+The goal for this phase was small and concrete: **an API that can list posts, return
+one post by its slug, and manage categories.** No auth yet, no comments yet. One new
+thing at a time.
+
+## Setting up the project
+
+Django's project/app split confused me at first, so here's the mental model that
+made it stick:
+
+- A **project** (`core/`) is the whole site's configuration — settings, the root
+  URL map, the WSGI entrypoint.
+- An **app** (`blog/`) is a self-contained feature — models, views, its own URLs.
+  A project is made of apps.
+
+```bash
+django-admin startproject core .
+python manage.py startapp blog
+```
+
+I added Django REST Framework, `django-cors-headers` (the frontend is on a different
+origin), and `django-environ` so settings come from the environment instead of being
+hard-coded:
+
+```python
+# core/settings.py
+env = environ.Env(DEBUG=(bool, False))
+environ.Env.read_env(BASE_DIR / ".env")
+
+SECRET_KEY = env("SECRET_KEY")
+DEBUG = env("DEBUG")
+DATABASES = {"default": env.db("DATABASE_URL")}   # postgres://…
+```
+
+That `env.db("DATABASE_URL")` line is lovely — one env var describes the whole
+database connection, and the same code works for local Postgres and a managed
+production database.
+
+## The models: where the thinking happens
+
+This is the part I'd tell any backend beginner to slow down on. **Your models are
+your app.** Everything else — the API, the admin, the frontend types — is a
+projection of them. I started with two.
+
+```python
+class Category(models.Model):
+    name = models.CharField(max_length=100)
+    slug = models.SlugField(unique=True)
+
+
+class Post(models.Model):
+    STATUS_DRAFT = "draft"
+    STATUS_PUBLISHED = "published"
+    STATUS_CHOICES = [(STATUS_DRAFT, "Draft"), (STATUS_PUBLISHED, "Published")]
+
+    title = models.CharField(max_length=200)
+    slug = models.SlugField(unique=True)
+    body = models.TextField()
+    category = models.ForeignKey(
+        Category, on_delete=models.SET_NULL, null=True, blank=True
+    )
+    status = models.CharField(max_length=10, choices=STATUS_CHOICES, default=STATUS_DRAFT)
+    published_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+```
+
+Small decisions that turned out to matter:
+
+- **`slug` is unique and drives the URL.** `/blog/my-first-post` reads better than
+  `/blog/1`, and it's stable if I reorder things.
+- **`status` (draft vs. published)** means I can save a half-finished post without it
+  going live. This one field shaped the whole API — every public query filters to
+  `published`.
+- **`on_delete=SET_NULL` for the category** — deleting a category shouldn't delete
+  the posts in it. Django *makes you* state what happens on delete, which forced me
+  to think about it. That's a feature.
+
+Then the two commands that still feel like magic:
+
+```bash
+python manage.py makemigrations   # turns model changes into a migration file
+python manage.py migrate          # applies them to the database
+```
+
+Migrations are version control for your database schema. Coming from hand-writing
+SQL, having Django diff my models and generate the change was the moment Django
+"sold" me.
+
+## The admin: a free CMS
+
+Three lines and I had a working content management UI:
+
+```python
+# blog/admin.py
+admin.site.register(Post)
+admin.site.register(Category)
+```
+
+`python manage.py createsuperuser`, log in at `/admin/`, and I could create posts in
+a browser. For a blog, the Django admin *is* the CMS. I didn't have to build one.
+
+## Turning models into an API with DRF
+
+DRF has two core pieces, and once they clicked the rest was repetition.
+
+**A serializer** translates between model instances and JSON, and validates incoming
+data. It's the membrane between Python objects and the wire.
+
+```python
+class PostSerializer(serializers.ModelSerializer):
+    category = CategorySerializer(read_only=True)          # nested on read
+    category_id = serializers.PrimaryKeyRelatedField(       # just an id on write
+        queryset=Category.objects.all(),
+        source="category", write_only=True,
+        required=False, allow_null=True,
+    )
+
+    class Meta:
+        model = Post
+        fields = ["id", "title", "slug", "body", "category",
+                  "category_id", "status", "published_at", "created_at"]
+```
+
+The read/write asymmetry took me a minute to appreciate: when the frontend *reads* a
+post it wants the full category object to display; when it *writes* one it only has
+an id to send. Exposing `category` (read-only, nested) and `category_id`
+(write-only) gives each side exactly what it needs from one serializer.
+
+**A view** decides which objects are exposed and how. DRF's generic views mean I
+describe intent, not plumbing:
+
+```python
+class PostListView(generics.ListCreateAPIView):
+    serializer_class = PostSerializer
+    def get_queryset(self):
+        return Post.objects.filter(status="published").order_by("-created_at")
+
+
+class PostDetailView(generics.RetrieveAPIView):
+    serializer_class = PostSerializer
+    lookup_field = "slug"                       # look posts up by slug, not id
+    def get_queryset(self):
+        return Post.objects.filter(status="published")
+```
+
+`ListCreateAPIView` gives me `GET` (list) and `POST` (create) for free;
+`RetrieveAPIView` gives me `GET` one. Because both querysets filter to
+`published`, **drafts are invisible to the API by construction** — there's no way to
+accidentally leak one, because the query never selects them.
+
+Finally, wire the URLs:
+
+```python
+# blog/urls.py
+urlpatterns = [
+    path("posts/", views.PostListView.as_view(), name="post-list"),
+    path("posts/<slug:slug>/", views.PostDetailView.as_view(), name="post-detail"),
+    path("categories/", views.CategoryListView.as_view(), name="category-list"),
+]
+```
+
+And I had a JSON API: `GET /api/posts/` returned my posts, `GET /api/posts/<slug>/`
+returned one. I tested it with the browser and `curl` before the frontend ever
+touched it.
+
+## CORS: the first "why isn't this working"
+
+The frontend (`localhost:3000`) and backend (`localhost:8000`) are different
+origins, so the browser blocked the requests until I told Django which origins to
+trust:
+
+```python
+CORS_ALLOWED_ORIGINS = env.list(
+    "CORS_ALLOWED_ORIGINS", default=["http://localhost:3000"]
+)
+```
+
+Reading it from the environment meant production could allow a different origin
+without a code change. This is the kind of thing that's obvious *after* you've spent
+twenty minutes staring at a blocked request in the network tab.
+
+## What I'd tell past me
+
+- **Spend your time on the models.** Get the fields, relationships, and
+  `on_delete` behaviour right; the API is a thin layer on top.
+- **A `status` field is worth more than it looks.** Draft/published gave me safe
+  authoring and defined every public query.
+- **Filter drafts in the queryset, not the view logic.** If the query can't select
+  it, you can't leak it.
+- **Let DRF's generic views do the work.** Describe *what* is exposed; don't
+  hand-roll request parsing.
+- **The Django admin is a real feature.** For content, it's a CMS you get for free.
+
+Next: connecting Next.js to this API with a typed client, rendering markdown posts —
+and then the part that took the longest, authentication.
+
+*Next: [Wiring It Together: Markdown and Auth →](./part-3-wiring-it-together-markdown-and-auth.md)*

--- a/blogs/part-3-wiring-it-together-markdown-and-auth.md
+++ b/blogs/part-3-wiring-it-together-markdown-and-auth.md
@@ -1,0 +1,234 @@
+# Part 3 — Wiring It Together: Markdown and Auth
+
+*Series: [Learning in Public](./README.md) · Prev: [← Building the Backend](./part-2-building-the-blog-backend-with-django.md) · Next: [Making It Real →](./part-4-comments-tests-ci-and-docker.md)*
+
+---
+
+Two apps that don't talk to each other aren't a full-stack app — they're two demos.
+This post is about the seam: connecting Next.js to Django with a typed client,
+rendering markdown posts, and then the piece that ate the most days by far —
+**authentication across two token systems**.
+
+## One typed client for the whole frontend
+
+I decided early that **exactly one file** would know how to talk to the backend:
+`src/lib/api.ts`. Every fetch lives there, and every request/response shape is a
+TypeScript interface. The rest of the app imports functions, never URLs.
+
+```ts
+export interface Post {
+  id: number;
+  title: string;
+  slug: string;
+  body: string;
+  category: Category | null;
+  status: string;
+  published_at: string | null;
+  created_at: string;
+}
+
+export async function getPosts(): Promise<Post[]> {
+  const res = await fetch(`${API_URL}/api/posts/`, { cache: "no-store" });
+  if (!res.ok) throw new Error("Failed to fetch posts");
+  return res.json();
+}
+```
+
+Two payoffs I felt immediately:
+
+- **The `Post` interface mirrors the DRF serializer.** When the two agree, the whole
+  app is type-safe end to end. When they drift, TypeScript tells me where.
+- **`cache: "no-store"`** means a freshly published post shows up on the next page
+  load — no rebuild. (That's a deliberate trade: correctness now over caching. Tuning
+  it is on my list.)
+
+## Server components render the blog for free
+
+Because App Router pages are server components, the blog list and detail pages fetch
+on the server and ship HTML — great for SEO, no client-side loading spinner:
+
+```tsx
+export default async function BlogPage() {
+  const [posts, session] = await Promise.all([getPosts(), auth()]);
+  // …render posts; show "Write a post" only if session?.isStaff
+}
+```
+
+The detail page fetches the post *and* its comments in parallel with
+`Promise.all` — a small thing that removes a request waterfall.
+
+## Rendering markdown
+
+Posts are stored as markdown in the database (that `body` TextField). On the detail
+page I render it with `react-markdown`, styled by the Tailwind Typography plugin so
+headings, lists, and code blocks look right without hand-writing CSS:
+
+```tsx
+<div className="prose prose-neutral dark:prose-invert max-w-none">
+  <ReactMarkdown>{post.body}</ReactMarkdown>
+</div>
+```
+
+For *writing* posts I added a markdown editor with live preview
+(`@uiw/react-md-editor`). It uses browser-only APIs, so it can't render on the
+server — the fix is a dynamic import with SSR turned off:
+
+```tsx
+const MDEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
+```
+
+That one line — `ssr: false` — is the answer to a whole category of "works in dev,
+explodes in build" errors. If a component reaches for `window`, it can't run on the
+server.
+
+## Authentication: the long part
+
+Here's the puzzle that took me longest to *understand*, let alone build. I had two
+different systems that each wanted to own "who is the user":
+
+- **Django (SimpleJWT)** issues JSON Web Tokens. My API trusts a request if it
+  carries a valid `Authorization: Bearer <token>`.
+- **NextAuth (v5)** manages the session on the frontend — the sign-in UI, the
+  session cookie, Google OAuth.
+
+The insight that unlocked it: **NextAuth owns the browser session; Django owns the
+API.** So NextAuth's job is to *obtain and carry a Django JWT* on the user's behalf.
+NextAuth is the front door; the JWT is the keycard it hands to the API.
+
+### Username + password
+
+The Credentials provider posts to Django's token endpoint and stashes the returned
+tokens on the NextAuth user:
+
+```ts
+Credentials({
+  async authorize(credentials) {
+    const res = await fetch(`${API_URL}/api/auth/token/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username: credentials.username,
+        password: credentials.password,
+      }),
+    });
+    if (!res.ok) return null;
+    const tokens = await res.json();
+    return {
+      id: credentials.username as string,
+      name: credentials.username as string,
+      accessToken: tokens.access,
+      refreshToken: tokens.refresh,
+      isStaff: tokens.is_staff ?? false,
+    };
+  },
+})
+```
+
+### Google sign-in, with a twist
+
+Google can tell me *who someone is*, but my Django API doesn't trust Google tokens —
+it trusts *its own* JWTs. So after a Google login I exchange the Google identity for
+a Django JWT in the NextAuth `jwt` callback:
+
+```ts
+if (account?.provider === "google" && user) {
+  const res = await fetch(`${API_URL}/api/auth/social/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: user.email, name: user.name }),
+  });
+  const tokens = await res.json();   // Django's access + refresh
+  return { ...token, accessToken: tokens.access, refreshToken: tokens.refresh, /* … */ };
+}
+```
+
+On the Django side, `SocialAuthView` finds or creates a user for that Google email
+and mints a JWT pair. It even de-duplicates usernames derived from the email's local
+part so two people named `noel@…` don't collide. So no matter *how* you sign in —
+password or Google — the app ends up holding the same kind of credential: a Django
+JWT. Everything downstream only has to understand one thing.
+
+### Keeping the token fresh
+
+Access tokens expire after an hour. Rather than let a request fail, the `jwt`
+callback refreshes the token ~5 minutes before expiry:
+
+```ts
+if (Date.now() < (token.accessTokenExpires ?? 0)) return token;  // still valid
+return refreshAccessToken(token);                                 // expired → refresh
+```
+
+Getting this wrong means users get logged out mid-action; getting it right means
+they never notice tokens exist at all. That's the goal — auth you can't feel.
+
+## Guarding routes and gating writes
+
+Two layers protect the author-only areas.
+
+**Frontend (middleware)** redirects anonymous users away from the create/categories
+pages before the page even renders:
+
+```ts
+export default auth((req) => {
+  const protectedPaths = ["/blog/create", "/blog/categories"];
+  const isProtected = protectedPaths.some((p) => req.nextUrl.pathname.startsWith(p));
+  if (isProtected && !req.auth) {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+});
+```
+
+**Backend (permissions)** is the one that actually matters — because anyone can
+bypass a frontend. Publishing requires a *staff* user:
+
+```python
+class IsStaffOrReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:      # GET/HEAD/OPTIONS → always allowed
+            return True
+        return bool(request.user and request.user.is_authenticated
+                    and request.user.is_staff)  # writes → staff only
+```
+
+**The lesson I want to underline: frontend guards are UX, backend permissions are
+security.** The middleware stops a signed-out visitor from seeing a form they can't
+use. `IsStaffOrReadOnly` stops a logged-in non-staff user from `POST`ing to
+`/api/posts/` with `curl`. You need both, and only one of them is optional.
+
+To make the staff check cheap on the frontend, I added `is_staff` as a claim on the
+token response, so the UI can hide the "Write a post" button without an extra API
+call:
+
+```python
+class StaffClaimTokenSerializer(TokenObtainPairSerializer):
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        data["is_staff"] = self.user.is_staff
+        return data
+```
+
+And because a login endpoint is a brute-force target, I throttled it — 5 attempts
+per minute, on its own scope so it doesn't affect normal reads:
+
+```python
+class LoginRateThrottle(AnonRateThrottle):
+    scope = "login"   # REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {"login": "5/minute"}
+```
+
+## What I'd tell past me
+
+- **Have exactly one API module.** One typed boundary keeps the frontend and backend
+  honest and makes drift a compile error.
+- **`ssr: false` for anything that touches `window`.** It's the fix for a whole
+  class of build-time crashes.
+- **Name who owns what.** NextAuth owns the browser session; Django owns the API.
+  Once I said that out loud, the token dance made sense.
+- **Normalise auth to one credential.** Password and Google both end as a Django JWT,
+  so the rest of the app only learns one thing.
+- **Frontend guards are UX; backend permissions are security.** Ship both, but never
+  trust the client.
+
+Next: letting readers talk back with comments and likes, then making the whole thing
+trustworthy with tests, CI, and Docker.
+
+*Next: [Making It Real: Comments, Tests, CI & Docker →](./part-4-comments-tests-ci-and-docker.md)*

--- a/blogs/part-4-comments-tests-ci-and-docker.md
+++ b/blogs/part-4-comments-tests-ci-and-docker.md
@@ -1,0 +1,212 @@
+# Part 4 — Making It Real: Comments, Tests, CI & Docker
+
+*Series: [Learning in Public](./README.md) · Prev: [← Wiring It Together](./part-3-wiring-it-together-markdown-and-auth.md)*
+
+---
+
+A blog you can read is nice. A blog people can *talk on*, that you can change without
+fear, and that runs the same everywhere — that's a real product. This post covers the
+last stretch of the journey so far: comments and likes, getting to 100% test
+coverage, a CI pipeline, and Docker. And because the project isn't finished, it ends
+with an honest look at what's still ahead.
+
+## Comments and likes
+
+Comments meant a third model, and my first real many-to-many relationship.
+
+```python
+class Comment(models.Model):
+    post = models.ForeignKey(Post, on_delete=models.CASCADE, related_name="comments")
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+                               related_name="comments")
+    body = models.TextField()
+    likes = models.ManyToManyField(settings.AUTH_USER_MODEL,
+                                   related_name="liked_comments", blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+```
+
+The `likes` field is where it got interesting. I first reached for a `like_count`
+integer — and immediately hit the classic bug: nothing stops the same person liking
+twice. A **many-to-many to `User`** fixes it by design: a user is either in the set or
+not, so a like is inherently one-per-person, and the count is just `likes.count()`.
+*Model the truth, and the bug becomes unrepresentable.*
+
+Two permission levels fell out naturally:
+
+- **Commenting** needs any signed-in user → `IsAuthenticatedOrReadOnly`.
+- **Publishing** needs staff → `IsStaffOrReadOnly` (from Part 3).
+
+The author and post are never trusted from the request body — they're set
+server-side from the token and the URL:
+
+```python
+def perform_create(self, serializer):
+    post = get_object_or_404(Post, slug=self.kwargs["slug"])
+    serializer.save(post=post, author=self.request.user)
+```
+
+Liking is a single **toggle** endpoint — the same call likes or unlikes, and returns
+the fresh truth so the client never has to guess:
+
+```python
+def post(self, request, slug, pk):
+    comment = get_object_or_404(Comment, pk=pk, post__slug=slug)
+    if request.user in comment.likes.all():
+        comment.likes.remove(request.user); liked = False
+    else:
+        comment.likes.add(request.user); liked = True
+    return Response({"like_count": comment.likes.count(), "liked": liked})
+```
+
+On the frontend, the comment section updates **optimistically** — the heart responds
+instantly, then reconciles with the server's real count:
+
+```tsx
+const result = await likeComment(slug, commentId, session.accessToken);
+setComments((prev) =>
+  prev.map((c) => (c.id === commentId ? { ...c, like_count: result.like_count } : c))
+);
+```
+
+The lesson: **let the server be the source of truth, but don't make the user wait for
+it.** Update the UI immediately, then trust the response.
+
+## Getting to 100% test coverage (on what matters)
+
+I'd shipped features without tests before and paid for it in regressions. This time I
+wanted a safety net — but I also didn't want to chase a meaningless "100%" by testing
+trivial files. So I did something I'd recommend: I picked the modules that carry real
+logic and demanded *full* coverage of *those*.
+
+```ts
+// vitest.config.ts
+coverage: {
+  provider: "v8",
+  include: [
+    "src/lib/api.ts",
+    "src/lib/handle-async.ts",
+    "src/components/layout/Header.tsx",
+    "src/components/blog/CommentSection.tsx",
+    "src/app/login/page.tsx",
+    "src/app/register/page.tsx",
+  ],
+  thresholds: { lines: 100, branches: 100, functions: 100, statements: 100 },
+}
+```
+
+The `include` list is the important idea. **100% coverage across a whole app is often
+vanity; 100% across your critical modules is a real guarantee.** The API client, the
+auth pages, and the comment UI are where a bug actually hurts — so those are locked
+in, and the build fails if coverage on them slips.
+
+On the backend, pytest (with `pytest-django`) covers the models and API endpoints —
+running against SQLite in CI for speed, Postgres locally for fidelity.
+
+Writing tests also *taught* me the app. Testing the token-refresh branch forced me to
+articulate exactly when a token is stale. Tests are a design review you run twice.
+
+## CI: the robot that says no
+
+I wired up GitHub Actions to run on every PR into `develop` and `main`, with five
+parallel jobs:
+
+| Job | What it checks |
+| --- | --- |
+| Backend — Ruff | Python lint + format |
+| Backend — Pytest | Django tests |
+| Frontend — ESLint | JS/TS lint + Prettier |
+| Frontend — Vitest | Tests + the 100% coverage gate |
+| Frontend — Build | `next build` actually compiles |
+
+Locally, Husky runs the fast checks on commit and the test suites on push, so I catch
+things before CI does:
+
+```sh
+# .husky/pre-commit
+cd backend && . venv/bin/activate && ruff format . && ruff check . && cd ..
+npx lint-staged
+npm run lint --workspace=frontend
+```
+
+The point of all this isn't ceremony — it's that **"it works on my machine" stops
+being something I have to promise.** The robot checks, every time, and I stopped
+being the bottleneck for "did I break the build?"
+
+## Docker: same everywhere
+
+The last piece was making the backend run identically anywhere. A slim Python image
+installs the dependencies and runs an entrypoint script:
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+RUN chmod +x entrypoint.sh
+EXPOSE 8000
+ENTRYPOINT ["./entrypoint.sh"]
+```
+
+The entrypoint migrates, collects static files, then hands off to **gunicorn** (the
+production server — `runserver` is for development only):
+
+```sh
+python manage.py migrate --noinput
+python manage.py collectstatic --noinput
+exec gunicorn core.wsgi:application --bind 0.0.0.0:8000 --workers 2 --timeout 120
+```
+
+Docker Compose ties the backend to a Postgres service — and the detail I'm proud of
+is the **healthcheck**: the backend waits until the database is genuinely ready, not
+just "started", so there's no race on boot.
+
+```yaml
+db:
+  image: postgres:16-alpine
+  healthcheck:
+    test: ["CMD-SHELL", "pg_isready -U portfolio_user -d portfolio_blog"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+backend:
+  build: ./backend
+  depends_on:
+    db:
+      condition: service_healthy   # wait for the DB, don't just start
+```
+
+`docker compose up --build` now brings the whole backend up from nothing — migrations
+and all — on any machine with Docker. Which, given that I *lost a machine* partway
+through this project, feels like the right note to end on.
+
+## Where we are — and what's next
+
+Everything above is live end-to-end: you can publish a markdown post, read it,
+comment, and like, on a tested and containerised stack. But the portfolio **isn't
+finished**, and I think it's worth being honest about that. Still ahead:
+
+- **Deployment** — Next.js to Vercel, Django + Postgres to Render/Fly/Railway.
+- **SEO** — per-post metadata (`generateMetadata`), `sitemap.xml`, `robots.txt`, and
+  JSON-LD structured data for articles.
+- **Blog polish** — pagination, category filtering, reading-time estimates, and
+  syntax highlighting in code blocks.
+- **Caching** — the API fetches are `no-store` today; there's a nicer balance to
+  strike with revalidation once traffic is real.
+
+## What I'd tell past me
+
+- **Model constraints instead of enforcing them in code.** A many-to-many made
+  "one like per user" a fact, not a rule I had to remember.
+- **Optimistic UI + server truth.** Respond instantly, reconcile with the response.
+- **Demand 100% coverage on the modules that matter, not the whole tree.** Aim the
+  guarantee where a bug actually costs you.
+- **Let a robot hold the standard.** CI + hooks mean quality isn't a thing I have to
+  remember to do.
+- **Containerise early.** The payoff isn't just deployment — it's that any machine,
+  including a brand-new one, is one command away from running your app.
+
+Thanks for following the journey. It's ongoing — I'll add to the series as the
+deployment and polish work lands.
+
+*Back to the [series index](./README.md).*

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,144 @@
+# API Reference
+
+Base URL: `${NEXT_PUBLIC_API_URL}` (e.g. `http://localhost:8000`).
+All endpoints are under `/api/`. Payloads are JSON.
+
+## Auth model
+
+- Authentication is **JWT bearer tokens** (`Authorization: Bearer <access>`),
+  issued by `djangorestframework-simplejwt`.
+- Access tokens live **1 hour**; refresh tokens live **7 days**.
+- DRF's default permission is `IsAuthenticatedOrReadOnly`; each view below states
+  its own rule.
+- `is_staff` is included in the token response so the frontend can gate write UI.
+
+## Posts
+
+### `GET /api/posts/`
+List published posts, newest first. **Public.**
+
+```json
+[
+  {
+    "id": 1,
+    "title": "From Static Site to Full Stack",
+    "slug": "from-static-site-to-full-stack",
+    "body": "# Markdown body…",
+    "category": { "id": 2, "name": "Journey", "slug": "journey" },
+    "status": "published",
+    "published_at": "2026-06-14T10:00:00Z",
+    "created_at": "2026-06-14T09:55:00Z"
+  }
+]
+```
+
+### `POST /api/posts/`
+Create a post. **Staff only** (`IsStaffOrReadOnly`).
+
+```json
+{
+  "title": "My post",
+  "slug": "my-post",
+  "body": "# Hello",
+  "category_id": 2,
+  "status": "published",
+  "published_at": "2026-07-13T12:00:00Z"
+}
+```
+
+`category_id` is write-only and optional; the response echoes the nested
+`category` object. `status` is `draft` or `published` — drafts are never returned
+by the list/detail endpoints.
+
+### `GET /api/posts/<slug>/`
+Retrieve one published post by slug. **Public.** `404` if it's a draft or missing.
+
+## Categories
+
+### `GET /api/categories/`
+List all categories. **Public.**
+
+### `POST /api/categories/`
+Create a category. **Staff only.**
+
+```json
+{ "name": "Django", "slug": "django" }
+```
+
+## Comments
+
+### `GET /api/posts/<slug>/comments/`
+List a post's comments, oldest first. **Public.**
+
+```json
+[
+  {
+    "id": 5,
+    "author_name": "noel",
+    "body": "Great write-up!",
+    "like_count": 3,
+    "created_at": "2026-06-15T08:30:00Z"
+  }
+]
+```
+
+### `POST /api/posts/<slug>/comments/`
+Add a comment. **Any authenticated user** (`IsAuthenticatedOrReadOnly`).
+The author and post are set server-side from the token and URL.
+
+```json
+{ "body": "Nice post!" }
+```
+
+### `POST /api/posts/<slug>/comments/<id>/like/`
+Toggle a like on a comment. **Authenticated.** Idempotent per user — calling it
+again removes the like. Returns the fresh state:
+
+```json
+{ "like_count": 4, "liked": true }
+```
+
+## Authentication endpoints
+
+### `POST /api/auth/register/`
+Create an account. **Public.** Validates unique username/email, min 8-char password.
+
+```json
+{ "username": "noel", "email": "noel@example.com", "password": "••••••••" }
+```
+
+### `POST /api/auth/token/`
+Obtain a JWT pair from username + password. **Public.** Rate limited to
+**5 requests/minute** per client. Response includes `is_staff`:
+
+```json
+{ "access": "…", "refresh": "…", "is_staff": true }
+```
+
+### `POST /api/auth/token/refresh/`
+Exchange a refresh token for a fresh access token. **Public.**
+
+```json
+{ "refresh": "…" }
+```
+
+### `POST /api/auth/social/`
+Server-to-server endpoint called by NextAuth after a successful Google sign-in.
+Finds or creates a Django user for the Google email and returns a JWT pair.
+**Public** (trusted because it's called from the NextAuth server callback).
+
+```json
+{ "email": "noel@example.com", "name": "Noel" }
+```
+
+## Status codes you'll see
+
+| Code | Meaning |
+| --- | --- |
+| `200` | OK |
+| `201` | Created (register, post, comment) |
+| `400` | Validation error (body echoes field errors) |
+| `401` | Missing/expired token — client refreshes or redirects to `/login` |
+| `403` | Authenticated but not staff (e.g. non-staff creating a post) |
+| `404` | Not found (or a draft post requested publicly) |
+| `429` | Login throttled (more than 5 attempts/minute) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,86 @@
+# Architecture
+
+## The big picture
+
+```
+┌─────────────────────────┐         HTTPS / JSON        ┌──────────────────────────┐
+│  Next.js 16 (frontend)  │  ───────────────────────▶   │  Django 6 + DRF (backend) │
+│  App Router, Tailwind   │   /api/posts, /api/auth…    │  gunicorn in production   │
+│  NextAuth v5            │  ◀───────────────────────   │                          │
+└───────────┬─────────────┘        JWT access token     └────────────┬─────────────┘
+            │                                                          │
+   renders in the browser                                     ┌────────▼────────┐
+   (server + client comps)                                    │   PostgreSQL     │
+                                                              └──────────────────┘
+```
+
+Two independently deployable apps talking over a JSON REST API. The frontend never
+touches the database directly — everything goes through DRF.
+
+## Frontend (Next.js, App Router)
+
+- **Server Components by default.** The blog list (`/blog`) and detail
+  (`/blog/[slug]`) pages are async server components that fetch from the API at
+  request time (`cache: "no-store"`), so new posts appear without a rebuild.
+- **Client Components where interactivity is needed** — the create page
+  (`/blog/create`) and the comment section (`"use client"`), which use hooks and
+  the browser-only markdown editor.
+- **Typed API client** (`src/lib/api.ts`) is the single boundary to the backend.
+  Every request/response shape is a TypeScript interface, so the whole app shares
+  one definition of a `Post`, `Comment`, and `Category`.
+- **Auth** is handled by NextAuth v5 (`src/auth.ts`). It stores the Django JWT in
+  the NextAuth session and refreshes it before expiry. `middleware.ts` guards the
+  author-only routes.
+
+## Backend (Django + DRF)
+
+- **`core/`** — project config. Settings read from the environment with
+  `django-environ`, including `DATABASE_URL` and `CORS_ALLOWED_ORIGINS`.
+- **`blog/`** — the single app that holds everything: models, serializers,
+  class-based DRF views, custom permissions, JWT token customisation, and auth
+  views for registration and social login.
+- **Auth strategy** — DRF's default is `IsAuthenticatedOrReadOnly`; individual
+  views tighten this. Writes to posts/categories require a *staff* user
+  (`IsStaffOrReadOnly`); commenting requires any authenticated user.
+
+## Data model
+
+```
+Category 1 ──── * Post 1 ──── * Comment * ──── * User (likes, M2M)
+                                   │
+                                   * ─── 1 User (author)
+```
+
+- **Category** — `name`, `slug`.
+- **Post** — `title`, `slug` (unique, used in URLs), `body` (markdown), optional
+  `category`, `status` (`draft` / `published`), `published_at`, `created_at`.
+  Only `published` posts are exposed by the API.
+- **Comment** — belongs to a `Post` and an author `User`; has a `likes`
+  many-to-many to `User` so each user can like a comment at most once.
+
+## Request lifecycle: publishing a post
+
+1. Staff user signs in → NextAuth stores a Django JWT (with an `is_staff` claim).
+2. They open `/blog/create` (middleware allows it because they're authenticated).
+3. They write markdown in the editor and submit.
+4. The browser `POST`s to `/api/posts/` with `Authorization: Bearer <jwt>`.
+5. DRF checks `IsStaffOrReadOnly` → allowed only if `is_staff`.
+6. The post is saved; the user is redirected to `/blog/<slug>`.
+
+## Request lifecycle: reading + commenting
+
+1. `/blog/[slug]` server-fetches the post **and** its comments in parallel.
+2. Markdown is rendered with `react-markdown` + the Tailwind Typography plugin.
+3. A signed-in reader posts a comment → `POST /api/posts/<slug>/comments/`.
+4. Liking a comment is a single toggle endpoint that adds/removes the user and
+   returns the fresh count; the UI updates optimistically.
+
+## Why this shape?
+
+- **SEO + speed** from Next.js server rendering.
+- **A real backend to learn on** — models, migrations, the admin, DRF, auth, and
+  Postgres, rather than locking content into frontend-only markdown files.
+- **Clear seam** between the two: the typed API client is the only contract, which
+  keeps the frontend and backend swappable and independently testable.
+
+See [API.md](./API.md) for the endpoint contract and [SETUP.md](./SETUP.md) to run it.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,56 @@
+# Build Journal
+
+A factual timeline of how the project was built, drawn from the git history.
+For the working checklist see [`../.claude/plan.md`](../.claude/plan.md).
+
+## Status
+
+- **Shipped:** full-stack blog — publish, read (markdown), comment, like.
+- **Tested:** Vitest at 100% on core modules; pytest on the backend; CI enforced.
+- **Containerised:** backend + Postgres via Docker Compose.
+- **Next:** production deployment, SEO, and blog polish (pagination, filtering).
+
+## Timeline
+
+### 2023 — the static portfolio
+
+A hand-written HTML/CSS/JS site: mobile menu, project popups, contact-form
+validation, and a long performance pass (WebP images, lazy-loading, minification,
+fixing layout shift and LCP). Deployed on GitHub Pages.
+
+### Apr 2026 — the rebuild decision
+
+- Revamped the static UI with dark mode, then decided to rebuild in Next.js.
+- Wrote the planning pack in `.claude/`: objectives, plan, roadmap.
+- Rebuilt the portfolio as a Next.js App Router app (Tailwind v4, shadcn/ui),
+  frontend-first with static data.
+
+### May 2026 — Django foundation
+
+- Scaffolded the Django `blog` app: `Category` + `Post` models, serializers, admin.
+- Configured CORS, environment variables, PostgreSQL, Ruff, and Husky hooks.
+
+### Jun 2026 — the blog comes alive
+
+- Built the blog list and detail pages against the Django API (typed client).
+- Added markdown rendering, then a markdown-editor create page.
+- Added JWT auth + Google OAuth (NextAuth v5) and middleware-protected routes.
+- Added staff-only publishing, an `is_staff` JWT claim, and login rate limiting.
+- Built comment threads with a like/unlike toggle.
+- Added the Vitest suite with 100% coverage enforcement.
+
+### Jun 14 2026 — containerisation
+
+- Dockerised the backend (gunicorn) with a Postgres service and healthcheck.
+
+### Jul 13 2026 — recovery + docs
+
+- Recovered the `.claude/` planning pack after a machine change (it lived on the
+  `feat/redo-portfolio-with-next` branch, not in the fresh clone).
+- Recreated this `docs/` folder and wrote the `blogs/` learning series.
+
+## What's left
+
+1. **Deploy** — Vercel (frontend) + Render/Fly/Railway (Django + Postgres).
+2. **SEO** — `generateMetadata` per post, `sitemap.xml`, `robots.txt`, JSON-LD.
+3. **Polish** — pagination, category filtering, reading time, code highlighting.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Documentation
+
+Project documentation for the portfolio + blog. Start here.
+
+| Doc | What it covers |
+| --- | --- |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | How the frontend, backend, and database fit together |
+| [SETUP.md](./SETUP.md) | Running the frontend, backend, and Docker locally |
+| [API.md](./API.md) | Every REST endpoint, its auth rules, and payloads |
+| [PROGRESS.md](./PROGRESS.md) | The build journal — what shipped, when, and what's next |
+
+## What is this project?
+
+A personal portfolio at [noellincoln.github.io](https://github.com/NoelLincoln/noellincoln.github.io)
+that started life in 2023 as a static HTML/CSS/JS site and was rebuilt in 2026 as a
+full-stack application:
+
+- **Frontend** — Next.js 16 (App Router), TypeScript, Tailwind v4, shadcn/ui.
+- **Backend** — Django 6 + Django REST Framework.
+- **Database** — PostgreSQL.
+- **Auth** — SimpleJWT on the API, NextAuth v5 (credentials + Google) on the client.
+- **Delivery** — Ruff/ESLint/Prettier, pytest + Vitest (100% on core modules),
+  GitHub Actions CI, Husky hooks, Docker for the backend.
+
+The headline feature is a **blog**: a staff user writes markdown posts through a
+protected create page, anyone can read them with rendered markdown, and signed-in
+readers can comment and like.
+
+> The learning story behind all of this is written up as a series in
+> [`../blogs/`](../blogs/README.md).
+
+## Repository layout
+
+```
+.
+├── frontend/          Next.js app (App Router)
+│   └── src/
+│       ├── app/       routes: /, /blog, /blog/[slug], /blog/create, /login, /register
+│       ├── components/ layout, sections, blog, ui (shadcn)
+│       ├── lib/       api client, async helper, utils
+│       ├── auth.ts    NextAuth config (providers, jwt/session callbacks)
+│       └── middleware.ts  route protection
+├── backend/           Django project
+│   ├── core/          settings, urls, wsgi/asgi
+│   └── blog/          models, serializers, views, permissions, auth, tests
+├── docs/              you are here
+├── blogs/             the learning-in-public series
+├── docker-compose.yml Postgres + backend
+└── .github/workflows/ CI
+```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,119 @@
+# Local Setup
+
+You can run the two apps directly, or run the backend + database with Docker.
+
+## Prerequisites
+
+- Node.js 22+
+- Python 3.12+
+- PostgreSQL 16 (or use the Docker Compose database)
+
+## 1. Backend (Django)
+
+```bash
+cd backend
+python -m venv venv
+. venv/bin/activate
+pip install -r requirements.txt
+```
+
+Create `backend/.env` (see `backend/.env.example`):
+
+```dotenv
+SECRET_KEY=dev-secret-change-me
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1
+DATABASE_URL=postgres://portfolio_user:password@localhost:5432/portfolio_blog
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+```
+
+Then migrate and run:
+
+```bash
+python manage.py migrate
+python manage.py createsuperuser   # gives you a staff user who can publish
+python manage.py runserver          # http://localhost:8000
+```
+
+The Django admin is at `http://localhost:8000/admin/`.
+
+> **Staff = author.** Only users with `is_staff=True` can create posts or
+> categories through the API. Your superuser is staff by default.
+
+## 2. Frontend (Next.js)
+
+```bash
+cd frontend
+npm install
+```
+
+Create `frontend/.env.local` (see the root `.env.example`):
+
+```dotenv
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXTAUTH_SECRET=dev-secret-change-me
+NEXTAUTH_URL=http://localhost:3000
+# Optional — only needed for Google sign-in:
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+```
+
+Then:
+
+```bash
+npm run dev    # http://localhost:3000
+```
+
+## 3. Docker (backend + Postgres)
+
+The root `docker-compose.yml` runs Postgres and the gunicorn-served backend.
+Provide a `.env` at the repo root with at least:
+
+```dotenv
+SECRET_KEY=...
+DB_PASSWORD=...
+ALLOWED_HOSTS=localhost,127.0.0.1
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+```
+
+```bash
+docker compose up --build
+```
+
+On start the backend `entrypoint.sh` runs migrations, collects static files, and
+launches gunicorn on port `8000`. Postgres data persists in the `postgres_data`
+volume, and the backend waits for the DB healthcheck before starting.
+
+## 4. Quality checks
+
+Frontend:
+
+```bash
+npm run lint --workspace=frontend
+npm run format:check --workspace=frontend
+npm test --workspace=frontend      # Vitest + coverage (100% on core modules)
+npm run build --workspace=frontend
+```
+
+Backend:
+
+```bash
+cd backend
+ruff check .
+ruff format --check .
+pytest
+```
+
+Husky runs the fast checks automatically on `git commit` (formatting, lint,
+lint-staged) and the test suites on `git push`. CI re-runs everything on PRs to
+`develop` and `main` — see `.github/workflows/linters.yml`.
+
+## Common gotchas
+
+- **CORS errors** — make sure the frontend origin is in `CORS_ALLOWED_ORIGINS`.
+- **401 on create/comment** — the JWT expired; the app refreshes automatically,
+  but if refresh fails you'll be redirected to `/login`.
+- **403 on create** — you're signed in but not `is_staff`. Flip the flag in the
+  Django admin.
+- **Markdown editor blank on first paint** — it's a client-only dynamic import
+  (`ssr: false`); that's expected.


### PR DESCRIPTION
## Summary

Documentation-only change. Recovers the `.claude/` planning pack (which only
survived on `feat/redo-portfolio-with-next`), refreshes it to match the current
state of the project, recreates a version-controlled `docs/` folder, and adds a
four-part "learning in public" blog series covering the journey so far.

No application code is touched.

## What's included

### 📓 `.claude/` — planning pack recovered & refreshed
- Restored the full pack: `objectives.md`, `nextjs-django-roadmap.md`, `transfer-to-new-project.md`.
- Updated `progress.md`, `plan.md`, and `objectives.md` to reflect reality — the
  blog is live end-to-end (auth, comments, tests, Docker), with deployment, SEO,
  and polish still ahead.

### 📚 `docs/` — recreated and now tracked
Human-facing project documentation for the current Next.js + Django + PostgreSQL stack:
- `README.md` — index and project overview.
- `ARCHITECTURE.md` — how frontend, backend, and DB fit together; data model; request lifecycles.
- `SETUP.md` — local dev (frontend, backend, Docker) and quality checks.
- `API.md` — full REST endpoint reference with auth rules and payloads.
- `PROGRESS.md` — build journal / timeline from 2023 static site to today.

This folder was previously gitignored (`# Local docs`), so it was never
version-controlled. That rule has been removed so it's preserved going forward.

### ✍️ `blogs/` — 4-part learning series
A journey-style series (with a `README.md` index), written up to the current state
and explicitly flagged as ongoing:
1. **From a Static Site to Full Stack** — why rebuild, choosing the stack, building the Next.js frontend.
2. **Building the Blog's Backend with Django + DRF** — models, admin, REST API, PostgreSQL.
3. **Wiring It Together: Markdown and Auth** — typed API client, markdown rendering, JWT + NextAuth + Google.
4. **Making It Real: Comments, Tests, CI & Docker** — comments/likes, 100% coverage, CI, Docker, and what's next.

## Why

- Prevents the recurrence of an earlier loss where uncommitted local docs
  disappeared on a machine change.
- Gives the repo real onboarding/architecture docs.
- Produces portfolio-ready blog content that documents the build.
