### PR TITLE
feat(analytics): add Google Analytics 4 and Microsoft Clarity

### DIFF
--- a/.claude/progress.md
+++ b/.claude/progress.md
@@ -69,9 +69,16 @@ Shipped:
 
 - Recovered the `.claude/` planning pack after a machine change.
 - Recreated the human-facing `docs/` folder and a multi-part learning blog series.
+- Added an interim **static-content blog fallback** (`feat/static-blog-fallback`)
+  so the blog renders on Vercel before the backend is deployed — `src/data/posts.json`
+  is served whenever `NEXT_PUBLIC_API_URL` is unset.
+- Added **analytics** (`feat/analytics`): Google Analytics 4 + Microsoft Clarity,
+  consolidated under `src/components/analytics/`, each gated on its own env var.
 
 ## Next 3 Actions
 
-1. Deploy: Next.js on Vercel, Django + Postgres on Render/Fly/Railway.
-2. SEO pass: `generateMetadata` per post, `sitemap.xml`, `robots.txt`, JSON-LD.
-3. Blog polish: pagination, category filtering, reading time, code highlighting.
+1. Set Vercel env and redeploy: `AUTH_SECRET`, `NEXT_PUBLIC_GA_ID` (and
+   `NEXT_PUBLIC_CLARITY_ID` once Clarity is set up); keep `NEXT_PUBLIC_API_URL` unset.
+2. Deploy the Django backend (Render/Fly/Railway), then set `NEXT_PUBLIC_API_URL`
+   to switch the blog from static content to the live API.
+3. SEO + blog polish: metadata, `sitemap.xml`, `robots.txt`, pagination, code highlighting.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,29 @@
-cd backend && . venv/bin/activate && ruff format . && ruff check . && cd ..
+#!/bin/sh
+set -e
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "$ROOT_DIR/backend"
+
+echo "[husky] Preparing backend environment"
+if [ ! -x venv/bin/python ]; then
+  python3 -m venv venv
+fi
+
+. venv/bin/activate
+
+if ! command -v ruff >/dev/null 2>&1; then
+  echo "[husky] Installing backend dependencies"
+  python -m pip install --upgrade pip
+  python -m pip install -r requirements.txt
+fi
+
+echo "[husky] Running backend Ruff format"
+ruff format .
+echo "[husky] Running backend Ruff checks"
+ruff check .
+
+cd "$ROOT_DIR"
+echo "[husky] Running staged-file checks"
 npx lint-staged
+echo "[husky] Running frontend lint"
 npm run lint --workspace=frontend

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,21 @@
-cd backend && . venv/bin/activate && (pytest || [ $? -eq 5 ])
-cd ../frontend && npm test
+#!/bin/sh
+set -e
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "$ROOT_DIR/backend"
+
+if [ ! -x venv/bin/python ]; then
+  python3 -m venv venv
+fi
+
+. venv/bin/activate
+
+if ! command -v pytest >/dev/null 2>&1; then
+  python -m pip install --upgrade pip >/dev/null
+  python -m pip install -r requirements.txt >/dev/null
+fi
+
+(pytest || [ $? -eq 5 ])
+
+cd "$ROOT_DIR/frontend"
+npm test

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -8,7 +8,8 @@ For the working checklist see [`../.claude/plan.md`](../.claude/plan.md).
 - **Shipped:** full-stack blog — publish, read (markdown), comment, like.
 - **Tested:** Vitest at 100% on core modules; pytest on the backend; CI enforced.
 - **Containerised:** backend + Postgres via Docker Compose.
-- **Next:** production deployment, SEO, and blog polish (pagination, filtering).
+- **Analytics:** Google Analytics 4 + Microsoft Clarity wired (env-gated).
+- **Next:** deploy the Django backend, SEO, and blog polish (pagination, filtering).
 
 ## Timeline
 
@@ -49,8 +50,16 @@ fixing layout shift and LCP). Deployed on GitHub Pages.
   `feat/redo-portfolio-with-next` branch, not in the fresh clone).
 - Recreated this `docs/` folder and wrote the `blogs/` learning series.
 
+### Jul 2026 — going live on the frontend
+
+- Added a static-content blog fallback so the frontend deploys on Vercel before
+  the backend exists (`src/data/posts.json`, served when `NEXT_PUBLIC_API_URL` is unset).
+- Added analytics — Google Analytics 4 + Microsoft Clarity — env-gated, under
+  `frontend/src/components/analytics/`.
+
 ## What's left
 
-1. **Deploy** — Vercel (frontend) + Render/Fly/Railway (Django + Postgres).
+1. **Deploy the backend** — Render/Fly/Railway (Django + Postgres); then point
+   `NEXT_PUBLIC_API_URL` at it to switch the blog off static content.
 2. **SEO** — `generateMetadata` per post, `sitemap.xml`, `robots.txt`, JSON-LD.
 3. **Polish** — pagination, category filtering, reading time, code highlighting.

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Script from "next/script";
 import "./globals.css";
 import { Providers } from "@/components/Providers";
 import { Toaster } from "@/components/ui/sonner";
+import Analytics from "@/components/analytics/Analytics";
 
 const poppins = Poppins({
   variable: "--font-poppins",
@@ -43,6 +44,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"
           strategy="afterInteractive"
         />
+        <Analytics />
       </body>
     </html>
   );

--- a/frontend/src/components/analytics/Analytics.tsx
+++ b/frontend/src/components/analytics/Analytics.tsx
@@ -1,0 +1,16 @@
+import GoogleAnalytics from "./GoogleAnalytics";
+import Clarity from "./Clarity";
+
+/**
+ * Single entry point for all analytics / telemetry scripts.
+ * Add new providers here so the root layout only ever mounts <Analytics />.
+ * Each provider self-gates on its own env var, so this is safe to always mount.
+ */
+export default function Analytics() {
+  return (
+    <>
+      <GoogleAnalytics />
+      <Clarity />
+    </>
+  );
+}

--- a/frontend/src/components/analytics/Clarity.tsx
+++ b/frontend/src/components/analytics/Clarity.tsx
@@ -1,0 +1,22 @@
+import Script from "next/script";
+
+const CLARITY_ID = process.env.NEXT_PUBLIC_CLARITY_ID;
+
+/**
+ * Microsoft Clarity — free heatmaps + session recordings.
+ * Renders nothing unless NEXT_PUBLIC_CLARITY_ID is set. Get the id from
+ * https://clarity.microsoft.com → your project → Settings → "Clarity project id".
+ */
+export default function Clarity() {
+  if (!CLARITY_ID) return null;
+
+  return (
+    <Script id="ms-clarity" strategy="afterInteractive">
+      {`(function(c,l,a,r,i,t,y){
+c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+})(window,document,"clarity","script","${CLARITY_ID}");`}
+    </Script>
+  );
+}

--- a/frontend/src/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/src/components/analytics/GoogleAnalytics.tsx
@@ -1,0 +1,28 @@
+import Script from "next/script";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+/**
+ * Google Analytics 4 (gtag.js).
+ * Renders nothing unless NEXT_PUBLIC_GA_ID is set, so local dev (where the var
+ * is absent) never pollutes your analytics. GA4 Enhanced Measurement tracks
+ * SPA route changes automatically, so no extra page-view wiring is needed.
+ */
+export default function GoogleAnalytics() {
+  if (!GA_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA_ID}');`}
+      </Script>
+    </>
+  );
+}


### PR DESCRIPTION
Consolidated, env-driven analytics under src/components/analytics:
- GoogleAnalytics.tsx — gtag.js, gated on NEXT_PUBLIC_GA_ID
- Clarity.tsx — heatmaps + session replay, gated on NEXT_PUBLIC_CLARITY_ID
- Analytics.tsx — composes both; mounted once in the root layout
