### PR TITLE
feat(hero): 3D particle hero, animated CTAs, and value cards

### DIFF
--- a/.claude/claude-code-workflow.md
+++ b/.claude/claude-code-workflow.md
@@ -1,11 +1,13 @@
 # Best Workflow with Claude Code
 
 ## Recommended Operating Mode
+
 - Work in small vertical slices (backend endpoint + frontend usage + test/check).
 - Keep a single source of truth for status in `.claude/plan.md` and `.claude/progress.md`.
 - Prefer short, explicit requests with one clear outcome per prompt.
 
 ## Prompt Template (Use This)
+
 1. Goal: what should be completed in this step.
 2. Constraints: files/scope not to touch, style requirements.
 3. Done criteria: exact checks to pass (lint/test/build).
@@ -14,49 +16,57 @@ Example:
 "Goal: implement BlogPost model + admin registration in backend only. Constraints: do not modify frontend. Done criteria: migrations generated and tests pass for blog app."
 
 ## Suggested Rhythm
+
 1. Start session:
+
 - Review `.claude/progress.md` and choose next unchecked item in `.claude/plan.md`.
 
 2. During session:
+
 - Ask Claude to implement one milestone-sized task.
 - Ask Claude to run/verify checks for that task.
 
 3. End session:
+
 - Mark completed checklist items in `.claude/plan.md`.
 - Add a short entry in `.claude/progress.md`.
 - Record next 1-3 actions.
 
 ## Branching Strategy
+
 - `develop` is the integration base branch.
 - All feature/fix/chore branches are created from updated `develop` and merged back into `develop`.
 - Goal: keep a clean, linear commit history on the main integration line.
 - Before starting any new feature/fix/chore, always create a new branch first.
 - Branch naming format is mandatory:
-	- `feat/description`
-	- `fix/description`
-	- `chore/description`
-	- `docs/description`
-	- `refactor/description`
+  - `feat/description`
+  - `fix/description`
+  - `chore/description`
+  - `docs/description`
+  - `refactor/description`
 - Keep branch names short, lowercase, and hyphen-separated.
 - One branch per milestone or focused feature.
 - Keep commits small and descriptive.
 - Open PRs early for feedback.
 
 ## Session Start Gate
+
 - Do not begin implementation work until branch creation is confirmed.
 - Always sync `develop` first, then create your branch.
 - Suggested first commands each session:
-	- `git fetch origin`
-	- `git checkout develop`
-	- `git pull --ff-only origin develop`
-	- `git checkout -b feat/your-description`
+  - `git fetch origin`
+  - `git checkout develop`
+  - `git pull --ff-only origin develop`
+  - `git checkout -b feat/your-description`
 
 ## Quality Gates per Step
+
 - Lint passes for touched files.
 - Build passes for touched app.
 - Basic manual verification for UI/API behavior.
 
 ## Practical Notes
+
 - Prefer project-local tools (`npm run ...`, `python -m ...`) over global latest `npx` when possible.
 - Keep environment setup scripted and documented.
 - If a task gets too broad, split it into smaller prompts.

--- a/.claude/nextjs-django-roadmap.md
+++ b/.claude/nextjs-django-roadmap.md
@@ -1,9 +1,11 @@
 # Next.js + Django Roadmap (Agreed Direction)
 
 ## Strategy Statement
+
 Yes, this is the right direction: use Next.js for SEO and frontend velocity, and Django/PostgreSQL for backend power and Python learning.
 
 ## Recommended Architecture
+
 - Frontend: Next.js (App Router) + Tailwind CSS
 - Backend: Django + Django REST Framework
 - Database: PostgreSQL
@@ -15,16 +17,19 @@ This gives strong SEO plus practical full-stack backend depth.
 ## Step-by-Step Implementation Plan
 
 ### 1) Define Scope and Data Model
+
 - Decide MVP pages: Home, Projects, Blog list, Blog detail, About, Contact, Admin.
 - Define models: Post, Category, Tag, Author, Project, ContactMessage.
 - Define required SEO fields: slug, meta_title, meta_description, og_image, published_at, status.
 
 ### 2) Set Up Repositories and Environments
+
 - Create frontend (Next.js + Tailwind) and backend (Django) folders.
 - Configure .env strategy for both apps.
 - Set up GitHub Actions early (lint + test on PR).
 
 ### 3) Build Django Backend Foundation
+
 - Initialize Django project, add DRF, CORS, PostgreSQL config.
 - Create blog app and core models.
 - Add Django admin customization for content editing.
@@ -36,12 +41,14 @@ This gives strong SEO plus practical full-stack backend depth.
 - Add serializers, validation, and basic permissions.
 
 ### 4) Build Next.js Frontend Foundation
+
 - Scaffold Next.js app with Tailwind and design tokens.
 - Create layout, header/nav, footer, responsive structure.
 - Migrate existing portfolio sections into reusable components.
 - Create typed API client for Django endpoints.
 
 ### 5) Implement Blog UI + SEO
+
 - Blog listing page with pagination and tag/category filters.
 - Blog detail page by slug.
 - Add Next.js metadata (generateMetadata) per post.
@@ -49,11 +56,13 @@ This gives strong SEO plus practical full-stack backend depth.
 - Add JSON-LD for blog posts.
 
 ### 6) Add Auth and Content Workflow (If Needed)
+
 - Start with Django admin-only publishing.
 - Optional later: add editor dashboard in Next.js with JWT/session auth.
 - Add draft/published workflow and preview support.
 
 ### 7) Add Advanced Portfolio Features
+
 - Project detail pages.
 - Search across posts/projects.
 - Related posts.
@@ -61,29 +70,34 @@ This gives strong SEO plus practical full-stack backend depth.
 - Newsletter or contact automation.
 
 ### 8) Quality and Testing
+
 - Backend tests: model + API tests.
 - Frontend tests: component tests + basic e2e paths.
 - Accessibility pass (headings, contrast, keyboard nav).
 - Performance pass (image optimization, caching, ISR/revalidation).
 
 ### 9) Deployment and Production Hardening
+
 - Deploy Django with managed Postgres.
 - Deploy Next.js on Vercel.
 - Configure CORS, allowed hosts, secure cookies/headers.
 - Add monitoring/logging and backups.
 
 ### 10) Ongoing Iteration
+
 - Add analytics.
 - Add CMS polish in Django admin.
 - Improve authoring flow and content templates.
 
 ## Learning Path (Python/Django + Next.js)
+
 - Week 1: Django models, admin, DRF serializers/views, Postgres basics.
 - Week 2: Build blog API and validation.
 - Week 3: Next.js App Router, metadata, data fetching, Tailwind system.
 - Week 4: Integrate both, deploy, and add SEO/structured data.
 
 ## Why This Fit Is Strong
+
 - SEO-first rendering from Next.js.
 - Deep Python/Django learning by owning models, APIs, admin, auth, and DB design.
 - Avoid locking blog content in frontend-only markdown files.

--- a/.claude/transfer-to-new-project.md
+++ b/.claude/transfer-to-new-project.md
@@ -1,10 +1,13 @@
 # Transfer .claude Pack to a New Project
 
 ## Purpose
+
 Use this file to copy the working planning system into another repository before implementation begins.
 
 ## Files to Copy
+
 Copy these files as a group into the target repo's `.claude/` directory:
+
 - `.claude/objectives.md`
 - `.claude/plan.md`
 - `.claude/progress.md`
@@ -13,17 +16,20 @@ Copy these files as a group into the target repo's `.claude/` directory:
 - `.claude/transfer-to-new-project.md`
 
 ## First-Time Setup in Target Repository
+
 1. Create and switch to `develop` if it does not exist yet.
 2. Ensure `develop` tracks `origin/develop`.
 3. Start all new tasks from updated `develop`.
 
 Recommended command flow:
+
 - `git fetch origin`
 - `git checkout develop`
 - `git pull --ff-only origin develop`
 - `git checkout -b feat/your-description`
 
 ## Session Workflow
+
 1. Review `.claude/progress.md`.
 2. Pick next unchecked item in `.claude/plan.md`.
 3. Implement one focused slice.
@@ -31,6 +37,7 @@ Recommended command flow:
 5. Update `.claude/progress.md` at session end.
 
 ## Notes
+
 - Keep branch names short, lowercase, and hyphenated.
 - Use one branch per feature/fix/chore.
 - Merge branches into `develop` to keep history linear.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,25 +1,26 @@
 {
-    "env": {
-      "browser": true,
-      "es6": true,
-      "jest": true
-    },
-    "parser": "babel-eslint",
-    "parserOptions": {
-      "ecmaVersion": 2018,
-      "sourceType": "module"
-    },
-    "extends": ["airbnb-base"],
-    "rules": {
-      "no-shadow": "off",
-      "no-param-reassign": "off",
-      "eol-last": "off",
-      "import/extensions": [ 1, {
-        "js": "always", "json": "always"
-      }]
-    },
-    "ignorePatterns": [
-      "dist/",
-      "build/"
+  "env": {
+    "browser": true,
+    "es6": true,
+    "jest": true
+  },
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "extends": ["airbnb-base"],
+  "rules": {
+    "no-shadow": "off",
+    "no-param-reassign": "off",
+    "eol-last": "off",
+    "import/extensions": [
+      1,
+      {
+        "js": "always",
+        "json": "always"
+      }
     ]
-  }
+  },
+  "ignorePatterns": ["dist/", "build/"]
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 # 📗 Table of Contents
 
 - [📖 About the Project](#about-project)
-
   - [🛠 Built With](#built-with)
     - [Tech Stack](#tech-stack)
     - [Key Features](#key-features)

--- a/blogs/README.md
+++ b/blogs/README.md
@@ -4,7 +4,7 @@ This is the story of taking my portfolio from a static HTML/CSS/JS site I built 
 2023 to a full-stack application with a Next.js frontend, a Django REST API, a
 PostgreSQL database, authentication, comments, tests, and Docker.
 
-I wrote it as a journey — the decisions, the dead ends, and the small "oh, *that's*
+I wrote it as a journey — the decisions, the dead ends, and the small "oh, _that's_
 how it works" moments — because that's the part tutorials skip. It's also **not
 finished**: the app is live end-to-end, but deployment, SEO, and polish are still
 ahead. I'll keep adding to the series as I go.
@@ -25,13 +25,13 @@ ahead. I'll keep adding to the series as I go.
 
 ## The stack, at a glance
 
-| Layer | Tech |
-| --- | --- |
-| Frontend | Next.js 16 (App Router), TypeScript, Tailwind v4, shadcn/ui |
-| Backend | Django 6, Django REST Framework |
-| Database | PostgreSQL 16 |
-| Auth | SimpleJWT (API) + NextAuth v5 (client), Google OAuth |
-| Tooling | Ruff, ESLint, Prettier, pytest, Vitest, Husky, GitHub Actions, Docker |
+| Layer    | Tech                                                                  |
+| -------- | --------------------------------------------------------------------- |
+| Frontend | Next.js 16 (App Router), TypeScript, Tailwind v4, shadcn/ui           |
+| Backend  | Django 6, Django REST Framework                                       |
+| Database | PostgreSQL 16                                                         |
+| Auth     | SimpleJWT (API) + NextAuth v5 (client), Google OAuth                  |
+| Tooling  | Ruff, ESLint, Prettier, pytest, Vitest, Husky, GitHub Actions, Docker |
 
 ## How to read it
 

--- a/blogs/part-1-from-static-site-to-full-stack.md
+++ b/blogs/part-1-from-static-site-to-full-stack.md
@@ -1,14 +1,14 @@
 # Part 1 — From a Static Site to Full Stack
 
-*Series: [Learning in Public](./README.md) · Next: [Building the Backend →](./part-2-building-the-blog-backend-with-django.md)*
+_Series: [Learning in Public](./README.md) · Next: [Building the Backend →](./part-2-building-the-blog-backend-with-django.md)_
 
 ---
 
 In 2023 I built my portfolio the honest way: hand-written HTML, CSS, and vanilla
 JavaScript, deployed to GitHub Pages. It had a mobile menu I wired up with event
 listeners, project cards that opened popups, a contact form with its own validation
-function, and — after a lot of commits with messages like *"solve largest
-contentful paint issue"* — a genuinely fast Lighthouse score. I converted images to
+function, and — after a lot of commits with messages like _"solve largest
+contentful paint issue"_ — a genuinely fast Lighthouse score. I converted images to
 WebP, lazy-loaded them, minified the CSS, and chased down layout shift.
 
 It worked. So why rebuild it?
@@ -17,7 +17,7 @@ It worked. So why rebuild it?
 
 Two reasons, and only one of them was technical.
 
-1. **I wanted to learn.** The static site had hit its ceiling as a *learning*
+1. **I wanted to learn.** The static site had hit its ceiling as a _learning_
    project. I could keep polishing pixels, but I wasn't learning anything new. I
    wanted to understand how a real full-stack app fits together: a backend, a
    database, authentication, an API contract between two apps.
@@ -25,8 +25,8 @@ Two reasons, and only one of them was technical.
    frontend — a real content system I could write into, with categories, drafts,
    and comments. That meant a database and an admin, which meant a backend.
 
-The rule I set for myself: *don't rebuild for the sake of it — rebuild to learn
-specific things.* I wrote those learning goals down before touching code.
+The rule I set for myself: _don't rebuild for the sake of it — rebuild to learn
+specific things._ I wrote those learning goals down before touching code.
 
 ## Choosing the stack
 
@@ -39,7 +39,7 @@ routing and data-fetching story that scales past "one HTML file per page."
 **Backend: Django + Django REST Framework.** I wanted to learn Python properly, and
 Django hands you an ORM, migrations, an admin UI, and auth out of the box. DRF turns
 models into a JSON API without much ceremony. For someone learning, "batteries
-included" was the whole point — I'd see how the pieces are *supposed* to fit before
+included" was the whole point — I'd see how the pieces are _supposed_ to fit before
 trying to assemble them myself.
 
 **Database: PostgreSQL.** The default serious choice, and the push I needed to stop
@@ -50,18 +50,18 @@ The principle I kept coming back to, straight from my planning notes:
 > Avoid locking blog content in frontend-only markdown files.
 
 Content belongs in a database you can query, moderate, and grow — not in the git
-history of your UI. (The *learning notes*, like this series, are fine as markdown.
+history of your UI. (The _learning notes_, like this series, are fine as markdown.
 Know which is which.)
 
 ## Planning before code
 
 Before writing a line, I wrote three short docs: **objectives** (product + learning
-goals, plus explicit *non-goals* to stop scope creep), **plan** (the build split
+goals, plus explicit _non-goals_ to stop scope creep), **plan** (the build split
 into one-branch-sized steps), and a **roadmap** (models → API → integration → auth →
 tests → deploy).
 
 This felt like overkill for a personal project. It wasn't. Months later I switched
-machines and lost my uncommitted working folder — those *committed* planning docs
+machines and lost my uncommitted working folder — those _committed_ planning docs
 were the thing that let me pick the thread back up. **Write down what you're doing
 and why, and commit it. Your future self is a different person with amnesia.**
 
@@ -69,10 +69,10 @@ and why, and commit it. Your future self is a different person with amnesia.**
 
 My first instinct was to build frontend and backend together. I changed my mind
 early and committed to a **frontend-first** approach: build the entire Next.js UI
-with *static, hard-coded data*, ship it, and only then start Django.
+with _static, hard-coded data_, ship it, and only then start Django.
 
 Why? It let me get a working, deployable site fast (motivation matters), learn
-Next.js without also fighting CORS and migrations, and define the *shape* of my data
+Next.js without also fighting CORS and migrations, and define the _shape_ of my data
 from the UI's needs before building an API to match. One new hard concept at a time.
 
 ## Building the frontend
@@ -129,4 +129,4 @@ frontend/src/
 Next up: the scary part for a frontend dev — building an actual backend. Django
 models, the admin, and turning them into a REST API.
 
-*Next: [Building the Blog's Backend with Django + DRF →](./part-2-building-the-blog-backend-with-django.md)*
+_Next: [Building the Blog's Backend with Django + DRF →](./part-2-building-the-blog-backend-with-django.md)_

--- a/blogs/part-2-building-the-blog-backend-with-django.md
+++ b/blogs/part-2-building-the-blog-backend-with-django.md
@@ -1,6 +1,6 @@
 # Part 2 — Building the Blog's Backend with Django + DRF
 
-*Series: [Learning in Public](./README.md) · Prev: [← From a Static Site to Full Stack](./part-1-from-static-site-to-full-stack.md) · Next: [Wiring It Together →](./part-3-wiring-it-together-markdown-and-auth.md)*
+_Series: [Learning in Public](./README.md) · Prev: [← From a Static Site to Full Stack](./part-1-from-static-site-to-full-stack.md) · Next: [Wiring It Together →](./part-3-wiring-it-together-markdown-and-auth.md)_
 
 ---
 
@@ -81,7 +81,7 @@ Small decisions that turned out to matter:
   going live. This one field shaped the whole API — every public query filters to
   `published`.
 - **`on_delete=SET_NULL` for the category** — deleting a category shouldn't delete
-  the posts in it. Django *makes you* state what happens on delete, which forced me
+  the posts in it. Django _makes you_ state what happens on delete, which forced me
   to think about it. That's a feature.
 
 Then the two commands that still feel like magic:
@@ -106,7 +106,7 @@ admin.site.register(Category)
 ```
 
 `python manage.py createsuperuser`, log in at `/admin/`, and I could create posts in
-a browser. For a blog, the Django admin *is* the CMS. I didn't have to build one.
+a browser. For a blog, the Django admin _is_ the CMS. I didn't have to build one.
 
 ## Turning models into an API with DRF
 
@@ -130,8 +130,8 @@ class PostSerializer(serializers.ModelSerializer):
                   "category_id", "status", "published_at", "created_at"]
 ```
 
-The read/write asymmetry took me a minute to appreciate: when the frontend *reads* a
-post it wants the full category object to display; when it *writes* one it only has
+The read/write asymmetry took me a minute to appreciate: when the frontend _reads_ a
+post it wants the full category object to display; when it _writes_ one it only has
 an id to send. Exposing `category` (read-only, nested) and `category_id`
 (write-only) gives each side exactly what it needs from one serializer.
 
@@ -185,7 +185,7 @@ CORS_ALLOWED_ORIGINS = env.list(
 ```
 
 Reading it from the environment meant production could allow a different origin
-without a code change. This is the kind of thing that's obvious *after* you've spent
+without a code change. This is the kind of thing that's obvious _after_ you've spent
 twenty minutes staring at a blocked request in the network tab.
 
 ## What I'd tell past me
@@ -196,11 +196,11 @@ twenty minutes staring at a blocked request in the network tab.
   authoring and defined every public query.
 - **Filter drafts in the queryset, not the view logic.** If the query can't select
   it, you can't leak it.
-- **Let DRF's generic views do the work.** Describe *what* is exposed; don't
+- **Let DRF's generic views do the work.** Describe _what_ is exposed; don't
   hand-roll request parsing.
 - **The Django admin is a real feature.** For content, it's a CMS you get for free.
 
 Next: connecting Next.js to this API with a typed client, rendering markdown posts —
 and then the part that took the longest, authentication.
 
-*Next: [Wiring It Together: Markdown and Auth →](./part-3-wiring-it-together-markdown-and-auth.md)*
+_Next: [Wiring It Together: Markdown and Auth →](./part-3-wiring-it-together-markdown-and-auth.md)_

--- a/blogs/part-3-wiring-it-together-markdown-and-auth.md
+++ b/blogs/part-3-wiring-it-together-markdown-and-auth.md
@@ -1,6 +1,6 @@
 # Part 3 — Wiring It Together: Markdown and Auth
 
-*Series: [Learning in Public](./README.md) · Prev: [← Building the Backend](./part-2-building-the-blog-backend-with-django.md) · Next: [Making It Real →](./part-4-comments-tests-ci-and-docker.md)*
+_Series: [Learning in Public](./README.md) · Prev: [← Building the Backend](./part-2-building-the-blog-backend-with-django.md) · Next: [Making It Real →](./part-4-comments-tests-ci-and-docker.md)_
 
 ---
 
@@ -54,7 +54,7 @@ export default async function BlogPage() {
 }
 ```
 
-The detail page fetches the post *and* its comments in parallel with
+The detail page fetches the post _and_ its comments in parallel with
 `Promise.all` — a small thing that removes a request waterfall.
 
 ## Rendering markdown
@@ -69,7 +69,7 @@ headings, lists, and code blocks look right without hand-writing CSS:
 </div>
 ```
 
-For *writing* posts I added a markdown editor with live preview
+For _writing_ posts I added a markdown editor with live preview
 (`@uiw/react-md-editor`). It uses browser-only APIs, so it can't render on the
 server — the fix is a dynamic import with SSR turned off:
 
@@ -83,7 +83,7 @@ server.
 
 ## Authentication: the long part
 
-Here's the puzzle that took me longest to *understand*, let alone build. I had two
+Here's the puzzle that took me longest to _understand_, let alone build. I had two
 different systems that each wanted to own "who is the user":
 
 - **Django (SimpleJWT)** issues JSON Web Tokens. My API trusts a request if it
@@ -92,7 +92,7 @@ different systems that each wanted to own "who is the user":
   session cookie, Google OAuth.
 
 The insight that unlocked it: **NextAuth owns the browser session; Django owns the
-API.** So NextAuth's job is to *obtain and carry a Django JWT* on the user's behalf.
+API.** So NextAuth's job is to _obtain and carry a Django JWT_ on the user's behalf.
 NextAuth is the front door; the JWT is the keycard it hands to the API.
 
 ### Username + password
@@ -121,13 +121,13 @@ Credentials({
       isStaff: tokens.is_staff ?? false,
     };
   },
-})
+});
 ```
 
 ### Google sign-in, with a twist
 
-Google can tell me *who someone is*, but my Django API doesn't trust Google tokens —
-it trusts *its own* JWTs. So after a Google login I exchange the Google identity for
+Google can tell me _who someone is_, but my Django API doesn't trust Google tokens —
+it trusts _its own_ JWTs. So after a Google login I exchange the Google identity for
 a Django JWT in the NextAuth `jwt` callback:
 
 ```ts
@@ -137,14 +137,18 @@ if (account?.provider === "google" && user) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email: user.email, name: user.name }),
   });
-  const tokens = await res.json();   // Django's access + refresh
-  return { ...token, accessToken: tokens.access, refreshToken: tokens.refresh, /* … */ };
+  const tokens = await res.json(); // Django's access + refresh
+  return {
+    ...token,
+    accessToken: tokens.access,
+    refreshToken: tokens.refresh /* … */,
+  };
 }
 ```
 
 On the Django side, `SocialAuthView` finds or creates a user for that Google email
 and mints a JWT pair. It even de-duplicates usernames derived from the email's local
-part so two people named `noel@…` don't collide. So no matter *how* you sign in —
+part so two people named `noel@…` don't collide. So no matter _how_ you sign in —
 password or Google — the app ends up holding the same kind of credential: a Django
 JWT. Everything downstream only has to understand one thing.
 
@@ -154,8 +158,8 @@ Access tokens expire after an hour. Rather than let a request fail, the `jwt`
 callback refreshes the token ~5 minutes before expiry:
 
 ```ts
-if (Date.now() < (token.accessTokenExpires ?? 0)) return token;  // still valid
-return refreshAccessToken(token);                                 // expired → refresh
+if (Date.now() < (token.accessTokenExpires ?? 0)) return token; // still valid
+return refreshAccessToken(token); // expired → refresh
 ```
 
 Getting this wrong means users get logged out mid-action; getting it right means
@@ -171,7 +175,9 @@ pages before the page even renders:
 ```ts
 export default auth((req) => {
   const protectedPaths = ["/blog/create", "/blog/categories"];
-  const isProtected = protectedPaths.some((p) => req.nextUrl.pathname.startsWith(p));
+  const isProtected = protectedPaths.some((p) =>
+    req.nextUrl.pathname.startsWith(p),
+  );
   if (isProtected && !req.auth) {
     return NextResponse.redirect(new URL("/login", req.url));
   }
@@ -179,7 +185,7 @@ export default auth((req) => {
 ```
 
 **Backend (permissions)** is the one that actually matters — because anyone can
-bypass a frontend. Publishing requires a *staff* user:
+bypass a frontend. Publishing requires a _staff_ user:
 
 ```python
 class IsStaffOrReadOnly(BasePermission):
@@ -231,4 +237,4 @@ class LoginRateThrottle(AnonRateThrottle):
 Next: letting readers talk back with comments and likes, then making the whole thing
 trustworthy with tests, CI, and Docker.
 
-*Next: [Making It Real: Comments, Tests, CI & Docker →](./part-4-comments-tests-ci-and-docker.md)*
+_Next: [Making It Real: Comments, Tests, CI & Docker →](./part-4-comments-tests-ci-and-docker.md)_

--- a/blogs/part-4-comments-tests-ci-and-docker.md
+++ b/blogs/part-4-comments-tests-ci-and-docker.md
@@ -1,10 +1,10 @@
 # Part 4 — Making It Real: Comments, Tests, CI & Docker
 
-*Series: [Learning in Public](./README.md) · Prev: [← Wiring It Together](./part-3-wiring-it-together-markdown-and-auth.md)*
+_Series: [Learning in Public](./README.md) · Prev: [← Wiring It Together](./part-3-wiring-it-together-markdown-and-auth.md)_
 
 ---
 
-A blog you can read is nice. A blog people can *talk on*, that you can change without
+A blog you can read is nice. A blog people can _talk on_, that you can change without
 fear, and that runs the same everywhere — that's a real product. This post covers the
 last stretch of the journey so far: comments and likes, getting to 100% test
 coverage, a CI pipeline, and Docker. And because the project isn't finished, it ends
@@ -29,7 +29,7 @@ The `likes` field is where it got interesting. I first reached for a `like_count
 integer — and immediately hit the classic bug: nothing stops the same person liking
 twice. A **many-to-many to `User`** fixes it by design: a user is either in the set or
 not, so a like is inherently one-per-person, and the count is just `likes.count()`.
-*Model the truth, and the bug becomes unrepresentable.*
+_Model the truth, and the bug becomes unrepresentable._
 
 Two permission levels fell out naturally:
 
@@ -64,7 +64,9 @@ instantly, then reconciles with the server's real count:
 ```tsx
 const result = await likeComment(slug, commentId, session.accessToken);
 setComments((prev) =>
-  prev.map((c) => (c.id === commentId ? { ...c, like_count: result.like_count } : c))
+  prev.map((c) =>
+    c.id === commentId ? { ...c, like_count: result.like_count } : c,
+  ),
 );
 ```
 
@@ -76,7 +78,7 @@ it.** Update the UI immediately, then trust the response.
 I'd shipped features without tests before and paid for it in regressions. This time I
 wanted a safety net — but I also didn't want to chase a meaningless "100%" by testing
 trivial files. So I did something I'd recommend: I picked the modules that carry real
-logic and demanded *full* coverage of *those*.
+logic and demanded _full_ coverage of _those_.
 
 ```ts
 // vitest.config.ts
@@ -102,7 +104,7 @@ in, and the build fails if coverage on them slips.
 On the backend, pytest (with `pytest-django`) covers the models and API endpoints —
 running against SQLite in CI for speed, Postgres locally for fidelity.
 
-Writing tests also *taught* me the app. Testing the token-refresh branch forced me to
+Writing tests also _taught_ me the app. Testing the token-refresh branch forced me to
 articulate exactly when a token is stale. Tests are a design review you run twice.
 
 ## CI: the robot that says no
@@ -110,13 +112,13 @@ articulate exactly when a token is stale. Tests are a design review you run twic
 I wired up GitHub Actions to run on every PR into `develop` and `main`, with five
 parallel jobs:
 
-| Job | What it checks |
-| --- | --- |
-| Backend — Ruff | Python lint + format |
-| Backend — Pytest | Django tests |
-| Frontend — ESLint | JS/TS lint + Prettier |
+| Job               | What it checks                 |
+| ----------------- | ------------------------------ |
+| Backend — Ruff    | Python lint + format           |
+| Backend — Pytest  | Django tests                   |
+| Frontend — ESLint | JS/TS lint + Prettier          |
 | Frontend — Vitest | Tests + the 100% coverage gate |
-| Frontend — Build | `next build` actually compiles |
+| Frontend — Build  | `next build` actually compiles |
 
 Locally, Husky runs the fast checks on commit and the test suites on push, so I catch
 things before CI does:
@@ -173,11 +175,11 @@ backend:
   build: ./backend
   depends_on:
     db:
-      condition: service_healthy   # wait for the DB, don't just start
+      condition: service_healthy # wait for the DB, don't just start
 ```
 
 `docker compose up --build` now brings the whole backend up from nothing — migrations
-and all — on any machine with Docker. Which, given that I *lost a machine* partway
+and all — on any machine with Docker. Which, given that I _lost a machine_ partway
 through this project, feels like the right note to end on.
 
 ## Where we are — and what's next
@@ -209,4 +211,4 @@ finished**, and I think it's worth being honest about that. Still ahead:
 Thanks for following the journey. It's ongoing — I'll add to the series as the
 deployment and polish work lands.
 
-*Back to the [series index](./README.md).*
+_Back to the [series index](./README.md)._

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,6 +15,7 @@ All endpoints are under `/api/`. Payloads are JSON.
 ## Posts
 
 ### `GET /api/posts/`
+
 List published posts, newest first. **Public.**
 
 ```json
@@ -33,6 +34,7 @@ List published posts, newest first. **Public.**
 ```
 
 ### `POST /api/posts/`
+
 Create a post. **Staff only** (`IsStaffOrReadOnly`).
 
 ```json
@@ -51,14 +53,17 @@ Create a post. **Staff only** (`IsStaffOrReadOnly`).
 by the list/detail endpoints.
 
 ### `GET /api/posts/<slug>/`
+
 Retrieve one published post by slug. **Public.** `404` if it's a draft or missing.
 
 ## Categories
 
 ### `GET /api/categories/`
+
 List all categories. **Public.**
 
 ### `POST /api/categories/`
+
 Create a category. **Staff only.**
 
 ```json
@@ -68,6 +73,7 @@ Create a category. **Staff only.**
 ## Comments
 
 ### `GET /api/posts/<slug>/comments/`
+
 List a post's comments, oldest first. **Public.**
 
 ```json
@@ -83,6 +89,7 @@ List a post's comments, oldest first. **Public.**
 ```
 
 ### `POST /api/posts/<slug>/comments/`
+
 Add a comment. **Any authenticated user** (`IsAuthenticatedOrReadOnly`).
 The author and post are set server-side from the token and URL.
 
@@ -91,6 +98,7 @@ The author and post are set server-side from the token and URL.
 ```
 
 ### `POST /api/posts/<slug>/comments/<id>/like/`
+
 Toggle a like on a comment. **Authenticated.** Idempotent per user — calling it
 again removes the like. Returns the fresh state:
 
@@ -101,6 +109,7 @@ again removes the like. Returns the fresh state:
 ## Authentication endpoints
 
 ### `POST /api/auth/register/`
+
 Create an account. **Public.** Validates unique username/email, min 8-char password.
 
 ```json
@@ -108,6 +117,7 @@ Create an account. **Public.** Validates unique username/email, min 8-char passw
 ```
 
 ### `POST /api/auth/token/`
+
 Obtain a JWT pair from username + password. **Public.** Rate limited to
 **5 requests/minute** per client. Response includes `is_staff`:
 
@@ -116,6 +126,7 @@ Obtain a JWT pair from username + password. **Public.** Rate limited to
 ```
 
 ### `POST /api/auth/token/refresh/`
+
 Exchange a refresh token for a fresh access token. **Public.**
 
 ```json
@@ -123,6 +134,7 @@ Exchange a refresh token for a fresh access token. **Public.**
 ```
 
 ### `POST /api/auth/social/`
+
 Server-to-server endpoint called by NextAuth after a successful Google sign-in.
 Finds or creates a Django user for the Google email and returns a JWT pair.
 **Public** (trusted because it's called from the NextAuth server callback).
@@ -133,12 +145,12 @@ Finds or creates a Django user for the Google email and returns a JWT pair.
 
 ## Status codes you'll see
 
-| Code | Meaning |
-| --- | --- |
-| `200` | OK |
-| `201` | Created (register, post, comment) |
-| `400` | Validation error (body echoes field errors) |
+| Code  | Meaning                                                           |
+| ----- | ----------------------------------------------------------------- |
+| `200` | OK                                                                |
+| `201` | Created (register, post, comment)                                 |
+| `400` | Validation error (body echoes field errors)                       |
 | `401` | Missing/expired token — client refreshes or redirects to `/login` |
-| `403` | Authenticated but not staff (e.g. non-staff creating a post) |
-| `404` | Not found (or a draft post requested publicly) |
-| `429` | Login throttled (more than 5 attempts/minute) |
+| `403` | Authenticated but not staff (e.g. non-staff creating a post)      |
+| `404` | Not found (or a draft post requested publicly)                    |
+| `429` | Login throttled (more than 5 attempts/minute)                     |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,8 +29,8 @@ touches the database directly — everything goes through DRF.
   Every request/response shape is a TypeScript interface, so the whole app shares
   one definition of a `Post`, `Comment`, and `Category`.
 - **Auth** is handled by NextAuth v5 (`src/auth.ts`). It stores the Django JWT in
-  the NextAuth session and refreshes it before expiry. `middleware.ts` guards the
-  author-only routes.
+  the NextAuth session and refreshes it before expiry. `proxy.ts` (the file
+  convention formerly called `middleware`) guards the author-only routes.
 
 ## Backend (Django + DRF)
 
@@ -40,7 +40,7 @@ touches the database directly — everything goes through DRF.
   class-based DRF views, custom permissions, JWT token customisation, and auth
   views for registration and social login.
 - **Auth strategy** — DRF's default is `IsAuthenticatedOrReadOnly`; individual
-  views tighten this. Writes to posts/categories require a *staff* user
+  views tighten this. Writes to posts/categories require a _staff_ user
   (`IsStaffOrReadOnly`); commenting requires any authenticated user.
 
 ## Data model
@@ -61,7 +61,7 @@ Category 1 ──── * Post 1 ──── * Comment * ──── * User (l
 ## Request lifecycle: publishing a post
 
 1. Staff user signs in → NextAuth stores a Django JWT (with an `is_staff` claim).
-2. They open `/blog/create` (middleware allows it because they're authenticated).
+2. They open `/blog/create` (the proxy allows it because they're authenticated).
 3. They write markdown in the editor and submit.
 4. The browser `POST`s to `/api/posts/` with `Authorization: Bearer <jwt>`.
 5. DRF checks `IsStaffOrReadOnly` → allowed only if `is_staff`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,12 @@
 
 Project documentation for the portfolio + blog. Start here.
 
-| Doc | What it covers |
-| --- | --- |
-| [ARCHITECTURE.md](./ARCHITECTURE.md) | How the frontend, backend, and database fit together |
-| [SETUP.md](./SETUP.md) | Running the frontend, backend, and Docker locally |
-| [API.md](./API.md) | Every REST endpoint, its auth rules, and payloads |
-| [PROGRESS.md](./PROGRESS.md) | The build journal — what shipped, when, and what's next |
+| Doc                                  | What it covers                                          |
+| ------------------------------------ | ------------------------------------------------------- |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | How the frontend, backend, and database fit together    |
+| [SETUP.md](./SETUP.md)               | Running the frontend, backend, and Docker locally       |
+| [API.md](./API.md)                   | Every REST endpoint, its auth rules, and payloads       |
+| [PROGRESS.md](./PROGRESS.md)         | The build journal — what shipped, when, and what's next |
 
 ## What is this project?
 
@@ -39,7 +39,7 @@ readers can comment and like.
 │       ├── components/ layout, sections, blog, ui (shadcn)
 │       ├── lib/       api client, async helper, utils
 │       ├── auth.ts    NextAuth config (providers, jwt/session callbacks)
-│       └── middleware.ts  route protection
+│       └── proxy.ts   route protection (formerly middleware.ts)
 ├── backend/           Django project
 │   ├── core/          settings, urls, wsgi/asgi
 │   └── blog/          models, serializers, views, permissions, auth, tests

--- a/docs/THREEJS-INSPIRATION.md
+++ b/docs/THREEJS-INSPIRATION.md
@@ -1,0 +1,170 @@
+# Three.js Inspiration Board
+
+A curated board for bringing WebGL / 3D into the portfolio — the ideas, the
+references, the stack, and the rules that keep it fast and accessible. Paired
+with the working prototype on the `feat/hero-3d` branch.
+
+For where this sits in the plan, see [`PROGRESS.md`](./PROGRESS.md).
+
+---
+
+## Where this fits the roadmap
+
+The current focus (per `PROGRESS.md` → _Next 3 Actions_) is **deploy the Django
+backend**, **Vercel env + redeploy**, and **SEO**. Those move the needle more
+for a portfolio than eye-candy, so 3D is a **parallel visual-polish track** — it
+should _not_ block those. Ship it timeboxed, behind the same performance
+discipline as the rest of the site.
+
+Think of it as **Phase 7 — visual polish**.
+
+---
+
+## The stack we're adding
+
+| Package                                    | Why                                                                                                   |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `three`                                    | The WebGL engine.                                                                                     |
+| `@react-three/fiber`                       | React renderer for three — declarative `<mesh>`/`<Points>` instead of imperative scene code.          |
+| `@react-three/drei`                        | Helpers: `Points`, `PointMaterial`, `Float`, `MeshDistortMaterial`, loaders, controls.                |
+| _(optional)_ `@react-three/postprocessing` | Bloom / glow / depth-of-field if we want a richer look.                                               |
+| _(optional)_ `maath`                       | Tiny math helpers (easing, random-in-sphere) — we hand-rolled this in the prototype to avoid the dep. |
+
+> ⚠️ **Compatibility:** this app is **React 19.2 + Next 16**. You need the
+> **`@react-three/fiber` v9 line** (v8 targets React 18) and a matching
+> `@react-three/drei` v10. Installing `@latest` gets you there — just don't pin
+> to an older major.
+>
+> **`three` is pinned to `0.182.0`** on purpose: three deprecated `THREE.Clock`
+> in r183 and logs a console warning, but r3f 9.7 still constructs a `Clock`
+> internally. `0.182.0` is the last release before that warning and satisfies
+> both r3f (`>=0.156`) and drei (`>=0.159`). Note the pin lives in a **root
+> `overrides`** block, not just `frontend/package.json`: r3f/drei peer-deps
+> otherwise hoist the latest `three` at the repo root — the copy r3f actually
+> loads — so a frontend-level dep alone doesn't win. Remove the override once r3f
+> migrates to `THREE.Timer`.
+
+**Install (you run this — at the repo root, it's an npm workspace):**
+
+```bash
+npm install three @react-three/fiber @react-three/drei --workspace=frontend
+# add @types/three if TS complains about three's types
+```
+
+---
+
+## What we already have that makes this easy
+
+The 3D work reuses tools already in the project — no extra libraries for motion,
+theming, or lazy-loading:
+
+- **`framer-motion`** → `useReducedMotion()` for the accessibility fallback, and
+  scroll-reveal orchestration around a canvas.
+- **`next-themes`** → `useTheme()` to recolour scenes for light/dark (the
+  prototype pulls the brand `--primary` per theme).
+- **`next/dynamic`** → the `ssr: false` lazy-load pattern (the canvas is
+  client-only; there's no `window` on the server). Mirrors the existing
+  `next/script` Lottie load in `layout.tsx`.
+- **Tailwind v4 tokens** (`globals.css`) → feed `--primary` / `--accent` into the
+  scene so 3D colours track the brand automatically.
+- **CI build gate** → catches any bundle/build regression the new deps introduce.
+
+---
+
+## Concept board
+
+Ranked roughly by impact-for-effort. ★ = shipped in the prototype.
+
+| Idea                         | What it is                                                                                                          | Effort   | Impact  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| **★ Ambient particle hero**  | A slow-drifting point field behind the hero, pointer parallax, theme-aware. Decorative background layer.            | Low      | High    |
+| **Floating 3D object**       | A distorted sphere / icosahedron (`Float` + `MeshDistortMaterial`) where the Lottie sits — a signature "hero prop". | Low–Med  | High    |
+| **Tilt project cards**       | Cards in `Projects` tilt in 3D toward the cursor (can be pure CSS 3D transforms — no three needed).                 | Low      | Med     |
+| **3D skills cloud**          | Skills/tech as labels on a rotating sphere (`drei` `Billboard`/`Text`).                                             | Med      | Med     |
+| **Scroll-driven object**     | A model that rotates/assembles as you scroll the About section (`drei` `ScrollControls`).                           | Med–High | High    |
+| **Shader gradient backdrop** | An animated GLSL gradient/noise plane behind a section — cheaper than particles, very "Awwwards".                   | Med      | Med     |
+| **3D 404 page**              | A playful floating scene on `not-found` — low stakes, high delight.                                                 | Low      | Low–Med |
+
+**Recommended sequence:** ship the ambient hero (done) → add the floating object
+as an alternative hero prop → tilt cards (cheap, CSS-only) → consider a
+scroll-driven About piece once the backend/SEO work is out of the way.
+
+---
+
+## The prototype (this branch)
+
+`feat/hero-3d` adds an **ambient particle field behind the hero**:
+
+- `frontend/src/components/three/HeroBackground.tsx` — the r3f `<Canvas>` +
+  procedural sphere of ~1,200 points, slow auto-rotation, pointer parallax,
+  confined to the right side with an alpha-mask fade on its left edge.
+- `frontend/src/hooks/useMediaQuery.ts` — SSR-safe media-query hook.
+- `frontend/src/components/sections/Hero.tsx` — lazy-loads the canvas with
+  `dynamic(..., { ssr: false })`, gates it behind `(min-width: 768px)`, and
+  layers it behind the content (`z-10`).
+
+It's built to the rules below out of the box:
+
+- **Decorative:** `pointer-events-none` + `aria-hidden` — never steals hero
+  clicks, invisible to screen readers.
+- **Legible:** the canvas is confined to the right side and its left edge is
+  alpha-masked, so particles read against the illustration and never touch — or
+  dim — the text column.
+- **Desktop-only:** gated at `≥md` (768px) — mobile never mounts the canvas or
+  downloads the WebGL chunk (mirrors the desktop-only Lottie).
+- **Motion-safe:** honours `prefers-reduced-motion` — renders the field **once**
+  (`frameloop="demand"`, zero rAF churn) instead of animating.
+- **Fail-safe:** feature-detects WebGL and wraps the canvas in an error boundary —
+  browsers that can't create a GL context (GPU disabled, some VMs) render nothing
+  instead of crashing the page.
+- **Theme-aware:** point colour/size/opacity tuned per theme (punchier in light,
+  softer in dark).
+- **LCP-safe:** transparent background layer; the hero heading stays the LCP.
+
+**Try it:**
+
+```bash
+npm run dev --workspace=frontend   # then open the homepage
+```
+
+---
+
+## Performance & accessibility rules
+
+These are non-negotiable — they're why the old static site scored well and we
+keep that here:
+
+1. **Lazy-load, client-only.** Always `dynamic(..., { ssr: false })`. `three` +
+   r3f + drei is a heavy chunk; keep it out of the initial bundle.
+2. **Protect the LCP.** 3D is decorative background/side content — never the
+   largest paintable element. Text stays the LCP.
+3. **Respect `prefers-reduced-motion`.** Pause the render loop
+   (`frameloop="demand"`) or drop the canvas entirely.
+4. **Cap the pixel ratio.** `dpr={[1, 2]}` — never render at raw retina density.
+5. **Start procedural.** Points/shaders need zero downloaded assets. Only reach
+   for glTF models when a concept truly needs one (and compress with Draco).
+6. **Don't fight the CI build.** New three components sit outside the 100%
+   Vitest coverage list, so no test burden — but the build must still pass.
+
+---
+
+## Learning resources
+
+- **Three.js Journey** — <https://threejs-journey.com> (Bruno Simon). The
+  definitive course; the r3f chapters map directly to this stack.
+- **React Three Fiber docs + examples** — <https://r3f.docs.pmnd.rs>
+- **drei docs** — <https://drei.docs.pmnd.rs> (copy-pasteable helpers).
+- **Codrops** — <https://tympanus.net/codrops> (filter "WebGL") — hero-background
+  tutorials with source.
+- **three.js examples** — <https://threejs.org/examples> — the official gallery.
+- **Inspiration:** Bruno Simon's portfolio (bruno-simon.com), and Awwwards'
+  WebGL collection for the bar.
+
+---
+
+## Next steps
+
+1. Eyeball the prototype (`npm run dev`), tune density/speed/colour to taste.
+2. Decide: keep the ambient field, or swap in the floating-object hero prop.
+3. Once deploy + SEO are moving, pick one "signature" interaction (scroll-driven
+   About, or the tilt cards) rather than sprinkling 3D everywhere.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,28 @@
+# Frontend environment variables.
+# Copy this file to `.env.local` and fill in the values you need:
+#   cp .env.example .env.local
+# `.env.local` is gitignored. Nothing here is required to boot the app except
+# AUTH_SECRET.
+
+# --- Auth (NextAuth v5) ---------------------------------------------------
+# REQUIRED. Without it, /api/auth/session returns 500 (MissingSecret).
+# Generate one with:  openssl rand -base64 32   (or: npx auth secret)
+AUTH_SECRET=
+
+# --- Backend API ----------------------------------------------------------
+# OPTIONAL. Leave UNSET to serve the blog from static content (src/data/posts.json).
+# Set it to the deployed Django API to switch the blog to the live backend, e.g.
+# NEXT_PUBLIC_API_URL=https://api.example.com
+NEXT_PUBLIC_API_URL=
+
+# --- Google OAuth ---------------------------------------------------------
+# OPTIONAL. Only needed to test "Sign in with Google" locally.
+# From https://console.cloud.google.com → Credentials → OAuth client ID.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# --- Analytics ------------------------------------------------------------
+# OPTIONAL. Each component renders nothing when its var is absent, so leaving
+# these blank is fine for local dev. Set them in the hosting provider for prod.
+NEXT_PUBLIC_GA_ID=
+NEXT_PUBLIC_CLARITY_ID=

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+# ...but keep the documented template tracked
+!.env.example
 
 # vercel
 .vercel

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@lottiefiles/react-lottie-player": "^3.6.0",
+    "@react-three/drei": "^10.7.8",
+    "@react-three/fiber": "^9.7.0",
     "@tailwindcss/typography": "^0.5.20",
     "@uiw/react-md-editor": "^4.1.1",
     "class-variance-authority": "^0.7.1",
@@ -30,6 +32,7 @@
     "shadcn": "^4.4.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
+    "three": "^0.182.0",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {

--- a/frontend/src/components/sections/About.tsx
+++ b/frontend/src/components/sections/About.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import AnimatedButton from "@/components/ui/animated-button";
 
 const skills = [
   {
@@ -114,15 +115,22 @@ export default function About() {
                 desc: "Architecture that grows with your business.",
               },
               { icon: "🤝", title: "Mentor & Lead", desc: "I grow teams, not just codebases." },
-            ].map(({ icon, title, desc }) => (
-              <div
+            ].map(({ icon, title, desc }, i) => (
+              <motion.div
                 key={title}
-                className="flex flex-col gap-1.5 p-3 rounded-xl bg-muted dark:bg-[#252836] border border-border"
+                className="group flex flex-col gap-1.5 p-3 rounded-xl bg-muted dark:bg-[#252836] border border-border hover:border-primary hover:shadow-md transition-colors cursor-default"
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.4, delay: i * 0.1 }}
+                whileHover={{ y: -6 }}
               >
-                <span className="text-xl">{icon}</span>
+                <span className="text-xl transition-transform duration-300 group-hover:scale-110 group-hover:rotate-6">
+                  {icon}
+                </span>
                 <p className="text-xs font-semibold text-[#172b4d] dark:text-[#e2e8f0]">{title}</p>
                 <p className="text-xs text-[#344563] dark:text-[#94a3b8]">{desc}</p>
-              </div>
+              </motion.div>
             ))}
           </div>
 
@@ -148,14 +156,15 @@ export default function About() {
             </div>
           </div>
 
-          <a
+          <AnimatedButton
             href="https://drive.google.com/file/d/1BpU8dTX44TQNiuD_cbhI-KtjGAPiA52w/view?usp=sharing"
             target="_blank"
             rel="noopener noreferrer"
-            className="w-fit mt-2 px-5 py-2.5 rounded-lg border border-primary text-primary text-sm font-medium hover:bg-primary hover:text-white transition-colors"
+            variant="outline"
+            className="w-fit mt-2"
           >
             Get my resume
-          </a>
+          </AnimatedButton>
         </motion.div>
 
         {/* Skills */}

--- a/frontend/src/components/sections/Contact.tsx
+++ b/frontend/src/components/sections/Contact.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { motion } from "framer-motion";
+import AnimatedButton from "@/components/ui/animated-button";
 
 export default function Contact() {
   const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
@@ -69,13 +70,14 @@ export default function Contact() {
             className="rounded-lg px-4 py-3 bg-white dark:bg-[#2d2a5e] text-[#172b4d] dark:text-[#e2e8f0] placeholder-gray-400 dark:placeholder-indigo-300 border border-transparent dark:border-[#4c4a8f] outline-none focus:ring-2 focus:ring-white/50 text-sm resize-none"
           />
 
-          <button
+          <AnimatedButton
             type="submit"
+            variant="onDark"
             disabled={status === "sending"}
-            className="w-fit px-6 py-3 rounded-lg bg-white dark:bg-[#4f46e5] text-primary dark:text-white font-medium text-sm hover:bg-indigo-50 dark:hover:bg-[#6366f1] transition-colors disabled:opacity-60"
+            className="w-fit px-6 py-3"
           >
             {status === "sending" ? "Sending…" : "Get in touch"}
-          </button>
+          </AnimatedButton>
 
           {status === "sent" && (
             <p className="text-green-300 text-sm">Message sent! I&apos;ll get back to you soon.</p>

--- a/frontend/src/components/sections/Hero.tsx
+++ b/frontend/src/components/sections/Hero.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useTypingAnimation } from "@/hooks/useTypingAnimation";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import AnimatedButton from "@/components/ui/animated-button";
 import { motion } from "framer-motion";
+import dynamic from "next/dynamic";
+
+// Client-only WebGL layer. `ssr: false` is legal here because this module is a
+// Client Component; the canvas never renders on the server (no `window` there).
+const HeroBackground = dynamic(() => import("@/components/three/HeroBackground"), {
+  ssr: false,
+});
 
 const socials = [
   { label: "Twitter", href: "https://twitter.com/Noel_Lincoln", icon: "/social/twitter.svg" },
@@ -16,12 +25,16 @@ const socials = [
 
 export default function Hero() {
   const displayed = useTypingAnimation("Hi, I'm Noel.\nGlad to see you!", 65);
+  // Only mount the WebGL layer on ≥md screens — keeps it off mobile entirely
+  // (the chunk isn't even requested), matching the desktop-only Lottie.
+  const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const lines = displayed.split("\n");
 
   return (
-    <section className="min-h-[580px] mt-14 flex items-center rounded-bl-[100px] bg-[#ddd0d0] dark:bg-[#141720] overflow-hidden">
-      <div className="max-w-7xl mx-auto w-full px-8 py-16 flex items-center justify-between gap-8">
+    <section className="relative min-h-[580px] mt-14 flex items-center rounded-bl-[100px] bg-[#ddd0d0] dark:bg-[#141720] overflow-hidden">
+      {isDesktop && <HeroBackground />}
+      <div className="relative z-10 max-w-7xl mx-auto w-full px-8 py-16 flex items-center justify-between gap-8">
         {/* Text */}
         <motion.div
           className="flex flex-col gap-4 max-w-xl"
@@ -51,18 +64,12 @@ export default function Hero() {
           </p>
 
           <div className="flex flex-wrap gap-3 mt-1">
-            <a
-              href="#projects"
-              className="px-5 py-2.5 rounded-lg bg-primary text-white text-sm font-medium hover:opacity-90 transition-opacity"
-            >
+            <AnimatedButton href="#projects" variant="primary">
               View My Work
-            </a>
-            <a
-              href="#contact"
-              className="px-5 py-2.5 rounded-lg border border-primary text-primary text-sm font-medium hover:bg-primary hover:text-white transition-colors"
-            >
+            </AnimatedButton>
+            <AnimatedButton href="#contact" variant="outline">
               Get in Touch
-            </a>
+            </AnimatedButton>
           </div>
 
           <div className="mt-2">

--- a/frontend/src/components/sections/Projects.tsx
+++ b/frontend/src/components/sections/Projects.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { projects, type Project } from "@/data/projects";
+import AnimatedButton from "@/components/ui/animated-button";
 
 export default function Projects() {
   const [selected, setSelected] = useState<Project | null>(null);
@@ -52,12 +53,13 @@ export default function Projects() {
                   {project.descrShort}
                 </p>
               </div>
-              <button
+              <AnimatedButton
+                variant="outline"
                 onClick={() => setSelected(project)}
-                className="w-fit px-5 py-2 rounded-lg border border-primary text-primary text-sm font-medium hover:bg-primary hover:text-white transition-colors"
+                className="w-fit px-5 py-2"
               >
                 See project
-              </button>
+              </AnimatedButton>
             </div>
           </motion.div>
         ))}

--- a/frontend/src/components/three/HeroBackground.tsx
+++ b/frontend/src/components/three/HeroBackground.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { Component, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { Points, PointMaterial } from "@react-three/drei";
+import { useReducedMotion } from "framer-motion";
+import { useTheme } from "next-themes";
+import type { Points as ThreePoints } from "three";
+
+/**
+ * Ambient WebGL particle field that sits *behind* the hero content.
+ *
+ * Design constraints (why it looks the way it does):
+ * - Decorative only: `pointer-events-none` + `aria-hidden`, so it never steals
+ *   clicks from the hero buttons and is skipped by screen readers.
+ * - Legible: a left-to-right scrim keeps the section colour opaque behind the
+ *   text column and fades to transparent on the right — particles read against
+ *   the illustration, never against the copy.
+ * - LCP-safe: the hero heading stays the largest paintable element; this is a
+ *   transparent background layer, lazy-loaded client-only via next/dynamic and
+ *   only mounted on ≥md screens (see Hero.tsx).
+ * - Motion-safe: when the OS requests reduced motion we render the field ONCE
+ *   (frameloop="demand", no per-frame work) instead of animating it.
+ * - Theme-aware: point colour/size/opacity track the active theme.
+ * - Fail-safe: if the browser can't create a WebGL context (GPU disabled, old
+ *   hardware, some VMs) we render nothing rather than crash — see `detectWebGL`
+ *   and `CanvasErrorBoundary` below.
+ */
+
+const COUNT = 1200;
+const RADIUS = 1.4;
+
+/**
+ * True only if this browser can actually create a WebGL context. Guards against
+ * environments where WebGL is disabled — three.js throws when it can't get a
+ * context, and an unhandled throw would take down the whole page.
+ */
+function detectWebGL(): boolean {
+  if (typeof window === "undefined" || !window.WebGLRenderingContext) return false;
+  try {
+    const canvas = document.createElement("canvas");
+    const gl = (canvas.getContext("webgl2") ||
+      canvas.getContext("webgl")) as WebGLRenderingContext | null;
+    if (!gl) return false;
+    // Free the probe context immediately so we don't hold a GPU slot.
+    gl.getExtension("WEBGL_lose_context")?.loseContext();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Backstop: if the canvas throws at runtime, drop it instead of crashing. */
+class CanvasErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+/** Uniformly scatter `count` points inside a sphere of `radius`. */
+function makePositions(count: number, radius: number): Float32Array {
+  const positions = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    // cube-root keeps the distribution even by volume rather than clumping at the centre
+    const r = radius * Math.cbrt(Math.random());
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.acos(2 * Math.random() - 1);
+    const sinPhi = Math.sin(phi);
+    positions[i * 3] = r * sinPhi * Math.cos(theta);
+    positions[i * 3 + 1] = r * sinPhi * Math.sin(theta);
+    positions[i * 3 + 2] = r * Math.cos(phi);
+  }
+  return positions;
+}
+
+function ParticleField({
+  color,
+  size,
+  opacity,
+  animate,
+  pointer,
+}: {
+  color: string;
+  size: number;
+  opacity: number;
+  animate: boolean;
+  pointer: React.RefObject<{ x: number; y: number }>;
+}) {
+  const ref = useRef<ThreePoints>(null);
+  const positions = useMemo(() => makePositions(COUNT, RADIUS), []);
+
+  useFrame((state, delta) => {
+    if (!animate || !ref.current) return;
+    // Slow, hypnotic auto-rotation — deliberately gentle.
+    ref.current.rotation.x -= delta / 22;
+    ref.current.rotation.y -= delta / 30;
+    // Subtle parallax: ease the camera toward the pointer, then re-centre its aim.
+    const p = pointer.current;
+    state.camera.position.x += (p.x * 0.35 - state.camera.position.x) * 0.03;
+    state.camera.position.y += (-p.y * 0.35 - state.camera.position.y) * 0.03;
+    state.camera.lookAt(0, 0, 0);
+  });
+
+  return (
+    <Points ref={ref} positions={positions} stride={3} frustumCulled={false}>
+      <PointMaterial
+        transparent
+        color={color}
+        size={size}
+        sizeAttenuation
+        depthWrite={false}
+        opacity={opacity}
+      />
+    </Points>
+  );
+}
+
+export default function HeroBackground() {
+  const prefersReducedMotion = useReducedMotion();
+  const { resolvedTheme } = useTheme();
+  const pointer = useRef({ x: 0, y: 0 });
+  // Null until checked on the client; false disables the canvas entirely.
+  const [webglOk, setWebglOk] = useState<boolean | null>(null);
+
+  const animate = !prefersReducedMotion;
+  const isDark = resolvedTheme === "dark";
+  // Deeper, larger, more opaque in light mode (the warm-grey bg washes out
+  // thin points); softer and lighter in dark mode so it never overpowers text.
+  const color = isDark ? "#a5b4fc" : "#4f46e5";
+  const size = isDark ? 0.02 : 0.026;
+  const opacity = isDark ? 0.85 : 0.95;
+
+  // Probe WebGL support once on the client.
+  useEffect(() => {
+    setWebglOk(detectWebGL());
+  }, []);
+
+  // Track the pointer at the window level so the canvas itself can stay
+  // `pointer-events-none` (never intercepting hero clicks).
+  useEffect(() => {
+    if (!animate) return;
+    const onMove = (e: PointerEvent) => {
+      pointer.current = {
+        x: (e.clientX / window.innerWidth) * 2 - 1,
+        y: (e.clientY / window.innerHeight) * 2 - 1,
+      };
+    };
+    window.addEventListener("pointermove", onMove, { passive: true });
+    return () => window.removeEventListener("pointermove", onMove);
+  }, [animate]);
+
+  // No canvas until we've confirmed WebGL works (avoids the context-creation
+  // throw on GPU-disabled browsers).
+  if (!webglOk) return null;
+
+  // Confine the canvas to the right side (behind the illustration) and fade its
+  // left edge with an alpha mask, so it never overlaps — or dims — the text
+  // column. A mask (not a colour scrim) means no theme-specific artifacts.
+  const maskFade = "linear-gradient(to right, transparent, black 30%)";
+
+  return (
+    <div
+      aria-hidden
+      className="absolute inset-y-0 right-0 w-[60%] pointer-events-none"
+      style={{ maskImage: maskFade, WebkitMaskImage: maskFade }}
+    >
+      <CanvasErrorBoundary>
+        <Canvas
+          camera={{ position: [0, 0, 2.2], fov: 55 }}
+          dpr={[1, 2]}
+          gl={{ antialias: false, alpha: true }}
+          frameloop={animate ? "always" : "demand"}
+        >
+          <ParticleField
+            color={color}
+            size={size}
+            opacity={opacity}
+            animate={animate}
+            pointer={pointer}
+          />
+        </Canvas>
+      </CanvasErrorBoundary>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/animated-button.tsx
+++ b/frontend/src/components/ui/animated-button.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
+import { motion, useMotionValue, useReducedMotion, useSpring } from "framer-motion";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Variant = "primary" | "outline" | "onDark";
+
+// easeOutExpo-ish — snappy in, gentle settle.
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+const DURATION = 0.35;
+
+const base =
+  "group relative inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-60 disabled:pointer-events-none";
+
+const skin: Record<Variant, string> = {
+  primary: "bg-primary text-white",
+  outline: "border border-primary text-primary",
+  onDark:
+    "bg-white text-primary hover:bg-indigo-50 dark:bg-[#4f46e5] dark:text-white dark:hover:bg-[#6366f1] transition-colors",
+};
+
+type Props = {
+  children: ReactNode;
+  variant?: Variant;
+  className?: string;
+  /** Render as an anchor. */
+  href?: string;
+  target?: string;
+  rel?: string;
+  /** Render as a button (when `href` is omitted). */
+  type?: "button" | "submit";
+  disabled?: boolean;
+  onClick?: () => void;
+};
+
+/**
+ * Shared CTA with three composed micro-interactions:
+ * - label roll: the text slides up and a duplicate rolls in from below on hover
+ * - arrow: nudges right and brightens
+ * - magnetic: the whole control eases toward the cursor, then springs back
+ *
+ * Polymorphic: renders a real `<a>` when `href` is set, otherwise a `<button>`
+ * (with `type`/`disabled`/`onClick`) — so links and form submits share one look.
+ * Accessibility: the rolled duplicate + arrow are `aria-hidden` (label announced
+ * once) and there's a visible focus ring. Under `prefers-reduced-motion` it
+ * degrades to a plain control with a simple CSS hover.
+ */
+export default function AnimatedButton({
+  children,
+  variant = "primary",
+  className,
+  href,
+  target,
+  rel,
+  type,
+  disabled,
+  onClick,
+}: Props) {
+  const prefersReducedMotion = useReducedMotion();
+  const ref = useRef<HTMLAnchorElement & HTMLButtonElement>(null);
+
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+  const springX = useSpring(x, { stiffness: 150, damping: 15, mass: 0.1 });
+  const springY = useSpring(y, { stiffness: 150, damping: 15, mass: 0.1 });
+
+  const classes = cn(base, skin[variant], className);
+
+  // Reduced motion: plain, fully-accessible control with a simple CSS hover.
+  if (prefersReducedMotion) {
+    const hoverFallback =
+      variant === "primary"
+        ? "hover:opacity-90 transition-opacity"
+        : variant === "outline"
+          ? "hover:bg-primary hover:text-white transition-colors"
+          : "";
+    const plainInner = (
+      <>
+        {children}
+        <ArrowRight className="h-4 w-4" aria-hidden />
+      </>
+    );
+    return href ? (
+      <a href={href} target={target} rel={rel} className={cn(classes, hoverFallback)}>
+        {plainInner}
+      </a>
+    ) : (
+      <button
+        type={type}
+        disabled={disabled}
+        onClick={onClick}
+        className={cn(classes, hoverFallback)}
+      >
+        {plainInner}
+      </button>
+    );
+  }
+
+  function handleMove(e: ReactPointerEvent<HTMLElement>) {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    x.set((e.clientX - (r.left + r.width / 2)) * 0.25);
+    y.set((e.clientY - (r.top + r.height / 2)) * 0.4);
+  }
+  function reset() {
+    x.set(0);
+    y.set(0);
+  }
+
+  const onHoverWhite =
+    variant === "outline" ? "transition-colors duration-300 group-hover:text-white" : "";
+
+  const inner = (
+    <>
+      {/* Outline variant: indigo fill sweeps up on hover (text flips to white below) */}
+      {variant === "outline" && (
+        <motion.span
+          aria-hidden
+          className="absolute inset-0 bg-primary"
+          variants={{ rest: { y: "101%" }, hover: { y: "0%" } }}
+          transition={{ duration: DURATION, ease: EASE }}
+        />
+      )}
+
+      {/* Label roll */}
+      <span className={cn("relative block overflow-hidden", onHoverWhite)}>
+        <motion.span
+          className="block"
+          variants={{ rest: { y: "0%" }, hover: { y: "-110%" } }}
+          transition={{ duration: DURATION, ease: EASE }}
+        >
+          {children}
+        </motion.span>
+        <motion.span
+          aria-hidden
+          className="absolute inset-0 block"
+          variants={{ rest: { y: "110%" }, hover: { y: "0%" } }}
+          transition={{ duration: DURATION, ease: EASE }}
+        >
+          {children}
+        </motion.span>
+      </span>
+
+      {/* Arrow */}
+      <motion.span
+        aria-hidden
+        className={cn("relative", onHoverWhite)}
+        variants={{ rest: { x: -2, opacity: 0.55 }, hover: { x: 2, opacity: 1 } }}
+        transition={{ duration: DURATION, ease: EASE }}
+      >
+        <ArrowRight className="h-4 w-4" />
+      </motion.span>
+    </>
+  );
+
+  const motionProps = {
+    className: classes,
+    style: { x: springX, y: springY },
+    initial: "rest" as const,
+    animate: "rest" as const,
+    whileHover: "hover" as const,
+    whileTap: { scale: 0.96 },
+    onPointerMove: handleMove,
+    onPointerLeave: reset,
+  };
+
+  return href ? (
+    <motion.a ref={ref} href={href} target={target} rel={rel} {...motionProps}>
+      {inner}
+    </motion.a>
+  ) : (
+    <motion.button ref={ref} type={type} disabled={disabled} onClick={onClick} {...motionProps}>
+      {inner}
+    </motion.button>
+  );
+}

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns whether `query` currently matches. SSR-safe: starts `false` on the
+ * server and first client render (so hydration matches), then updates after
+ * mount. Use it to keep expensive client-only UI (e.g. WebGL) off small screens.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,3 +1,6 @@
+// Proxy (formerly the `middleware` convention, renamed in Next 16) — guards the
+// authenticated blog routes, redirecting signed-out visitors to /login. The
+// NextAuth `auth()` wrapper is the single default export the proxy file expects.
 import { auth } from "@/auth";
 import { NextResponse } from "next/server";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "@lottiefiles/react-lottie-player": "^3.6.0",
+        "@react-three/drei": "^10.7.8",
+        "@react-three/fiber": "^9.7.0",
         "@tailwindcss/typography": "^0.5.20",
         "@uiw/react-md-editor": "^4.1.1",
         "class-variance-authority": "^0.7.1",
@@ -45,6 +47,7 @@
         "shadcn": "^4.4.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
+        "three": "^0.182.0",
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
@@ -234,23 +237,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "frontend/node_modules/canvas": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
-      "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "^7.1.3"
-      },
-      "engines": {
-        "node": "^18.12.0 || >= 20.9.0"
       }
     },
     "frontend/node_modules/css-tree": {
@@ -1033,31 +1019,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "frontend/node_modules/sugarss": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-5.0.1.tgz",
-      "integrity": "sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
-    },
     "frontend/node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -1219,24 +1180,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "frontend/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2105,6 +2048,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.61.5",
@@ -4612,6 +4561,12 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -4667,6 +4622,18 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -4991,6 +4958,118 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.8",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.8.tgz",
+      "integrity": "sha512-rJXyuzLm2Xq0kafHuR47ajDGbOe/pEhzIr4m8E8zwzQs0iNjloFDqBwRhrXmP/w+onLeYyN3EYPFW/cwWK/4yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
+      "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -5882,6 +5961,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -5947,6 +6032,12 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -6040,6 +6131,12 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -6078,6 +6175,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -6097,11 +6203,31 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.4",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.4.tgz",
+      "integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -6112,6 +6238,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -6577,6 +6709,24 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.8",
@@ -7404,7 +7554,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7456,7 +7605,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -7885,6 +8033,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -8743,6 +8904,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -9286,6 +9465,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -9465,6 +9653,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -10550,18 +10744,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -10852,6 +11034,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -11451,15 +11639,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -11624,6 +11803,12 @@
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
     },
     "node_modules/gonzales-pe": {
       "version": "4.3.0",
@@ -12396,6 +12581,12 @@
         "@hint/configuration-web-recommended": "^8.2.23"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.17.tgz",
+      "integrity": "sha512-NUplVGVuc1hSPwdB/9/cbRkUmLrYi75/hqiXKdA+l300pJNxDu96R7jRb2imDzWJqIUF4I5ThmAdp9GvOCXsuQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/hono": {
       "version": "4.12.14",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
@@ -12669,7 +12860,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12709,6 +12899,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -13648,6 +13844,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
@@ -14028,6 +14236,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -14969,6 +15186,16 @@
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
       }
     },
     "node_modules/magic-string": {
@@ -16837,6 +17064,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
+    },
     "node_modules/metaviewport-parser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
@@ -17834,15 +18076,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -17963,30 +18196,6 @@
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -19199,6 +19408,12 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -19228,64 +19443,6 @@
       "license": "MIT",
       "peerDependencies": {
         "preact": ">=10"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -19405,6 +19562,22 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
+    "node_modules/promise-worker-transferable/node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -19939,6 +20112,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-pkg": {
@@ -23196,6 +23384,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -23917,6 +24131,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -24090,6 +24313,44 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.11.tgz",
+      "integrity": "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg==",
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -24312,6 +24573,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.5.tgz",
+      "integrity": "sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.5",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.5.tgz",
+      "integrity": "sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -24379,19 +24670,41 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
       "dependencies": {
-        "safe-buffer": "^5.0.1"
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/tw-animate-css": {
@@ -25022,6 +25335,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -25309,31 +25631,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/vitest/node_modules/sugarss": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-5.0.1.tgz",
-      "integrity": "sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
-    },
     "node_modules/vitest/node_modules/vite": {
       "version": "8.0.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
@@ -25412,24 +25709,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
@@ -25470,6 +25749,17 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -26051,6 +26341,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
       "prettier --write"
     ]
   },
+  "overrides": {
+    "three": "0.182.0",
+    "stats-gl": {
+      "three": "0.170.0"
+    }
+  },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "concurrently": "^10.0.3",


### PR DESCRIPTION
Add an ambient WebGL particle field behind the hero (react-three-fiber + drei): auto-rotates, eases toward the cursor, recolours per theme. Hardened for production — WebGL feature-detect plus an error boundary (renders nothing instead of crashing when GL is unavailable), desktop-only mount, and a static single render under prefers-reduced-motion.

Add a shared AnimatedButton (Framer Motion) used by every CTA — hero, "See project", the contact submit, and "Get my resume". Composes a label roll, an arrow nudge, and a magnetic cursor pull; polymorphic across <a>/<button> (href / onClick / type=submit / disabled) with primary, outline, and onDark skins. Falls back to a plain control with a CSS hover under reduced motion.

Animate the About value cards: staggered scroll-in, hover lift, and an icon pop.

Local-dev housekeeping surfaced while building this:
- rename middleware.ts -> proxy.ts (Next 16 renamed the file convention)
- add frontend/.env.example (+ a .gitignore exception) documenting AUTH_SECRET and friends, so a fresh clone boots without the MissingSecret 500
- pin three to 0.182.0 via a root overrides block: r3f 9.7 still constructs THREE.Clock, deprecated in three r183, which logs a console warning
- docs: Three.js inspiration board, and proxy references in ARCHITECTURE/README